### PR TITLE
Downmarkerfarbe + Grouplead-Check Update

### DIFF
--- a/addons/OPT/GPS/fn_IsUnitLeader.sqf
+++ b/addons/OPT/GPS/fn_IsUnitLeader.sqf
@@ -28,4 +28,12 @@
 
 params ["_unit"];
 
-_unit == leader group _unit;
+switch (typeOf _unit) do {
+	case "OPT_NATO_Gruppenfuehrer";
+	case "OPT_CSAT_Gruppenfuehrer";
+	case "OPT_NATO_Offizier";
+	case "OPT_CSAT_Offizier";
+	case "OPT_NATO_Pilot";
+	case "OPT_CSAT_Pilot": { true };
+	default { false };
+};

--- a/addons/OPT/GPS/fn_addUnitToGPS.sqf
+++ b/addons/OPT/GPS/fn_addUnitToGPS.sqf
@@ -73,10 +73,8 @@ private _unitIcon = ["ICON",
             _texture = "\A3\ui_f\data\igui\cfg\revive\overlayicons\u100_ca.paa";
             if (_position getVariable ["FAR_IsStabilized", 0] == 1) then {
                 _color = [0.850, 0.4, 0, 1];
-                _text = format ["%1 (%2)", name _position, "Stabilisiert" ];
             } else {
                 _color = [1, 0, 0, 1];
-                _text = format ["%1 (%2)", name _position, "Verwundet"];
             };
             _width = 30;
             _height = 30;

--- a/addons/OPT/GPS/fn_addUnitToGPS.sqf
+++ b/addons/OPT/GPS/fn_addUnitToGPS.sqf
@@ -71,7 +71,13 @@ private _unitIcon = ["ICON",
         //Show wounded marker if downed
         if (_position getVariable ["FAR_isUnconscious", 0] == 1) then {
             _texture = "\A3\ui_f\data\igui\cfg\revive\overlayicons\u100_ca.paa";
-            _color = [1, 0, 0, 1];
+            if (_position getVariable ["FAR_IsStabilized", 0] == 1) then {
+                _color = [0.850, 0.4, 0, 1];
+                _text = format ["%1 (%2)", name _position, "Stabilisiert" ];
+            } else {
+                _color = [1, 0, 0, 1];
+                _text = format ["%1 (%2)", name _position, "Verwundet"];
+            };
             _width = 30;
             _height = 30;
             _angle = 0;


### PR DESCRIPTION
- Down-Marker ändert Farbe auf Orange, wenn Spieler stabilisiert wurde
- Gruppenführer-Status wird jetzt hart in Abhängigkeit vom Unittype erkannt (nur Offizier, Gruppenführer, Pilot)