### PR TITLE
Extra Killed EH for marker removal

### DIFF
--- a/addons/OPT/GPS/fn_IsUnitLeader.sqf
+++ b/addons/OPT/GPS/fn_IsUnitLeader.sqf
@@ -28,12 +28,11 @@
 
 params ["_unit"];
 
-switch (typeOf _unit) do {
-	case "OPT_NATO_Gruppenfuehrer";
-	case "OPT_CSAT_Gruppenfuehrer";
-	case "OPT_NATO_Offizier";
-	case "OPT_CSAT_Offizier";
-	case "OPT_NATO_Pilot";
-	case "OPT_CSAT_Pilot": { true };
-	default { false };
-};
+typeof _unit in [
+	"OPT_NATO_Gruppenfuehrer", 
+	"OPT_CSAT_Gruppenfuehrer",
+	"OPT_NATO_Offizier",
+	"OPT_CSAT_Offizier",
+	"OPT_NATO_Pilot",
+	"OPT_CSAT_Pilot"
+];

--- a/addons/OPT/GPS/fn_clientInit.sqf
+++ b/addons/OPT/GPS/fn_clientInit.sqf
@@ -23,6 +23,11 @@ GVAR(lastProcessedIcons) = [];
         ((findDisplay 444001) displayCtrl 10007) call CFUNC(registerMapControl);
     }, {!(isNull ((findDisplay 12) displayCtrl 51))}] call CFUNC(waitUntil);
 
+    // UAV Display
+    [{
+        ((findDisplay 160) displayCtrl 51) call CFUNC(registerMapControl);
+    }, {!(isNull ((findDisplay 160) displayCtrl 51))}] call CFUNC(waitUntil);
+
 }] call CFUNC(addEventhandler);
 
 
@@ -118,23 +123,6 @@ if (_units isEqualTo [] && _vehicles isEqualTo []) then {
         GVAR(lastFrameTriggered) = diag_frameNo;
     };
 }] call CFUNC(addEventhandler);
-
-
-
-// ["MPKilled", {
-// 	params ["_unit", "_killer", "_instigator", "_useEffects"];
-//     _unit = _unit select 0;
-//     DUMP("KILLED");
-//     DUMP(_unit);
-//     DUMP(group _unit);
-//     DUMP(group CLib_Player);
-//     DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
-//     private _iconId = toLower format [QGVAR(IconId_Player_%1_%2), _unit, group _unit isEqualTo group CLib_Player];
-//     [_iconId] call CFUNC(removeMapGraphicsGroup);
-//     DUMP("ICON REMOVED BECAUSE KILLED: " + _iconId);
-//     DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
-
-// }] call CFUNC(addEventhandler);
 
 
 player addMPEventHandler ["MPKilled", {

--- a/addons/OPT/GPS/fn_clientInit.sqf
+++ b/addons/OPT/GPS/fn_clientInit.sqf
@@ -118,3 +118,22 @@ if (_units isEqualTo [] && _vehicles isEqualTo []) then {
         GVAR(lastFrameTriggered) = diag_frameNo;
     };
 }] call CFUNC(addEventhandler);
+
+
+
+["Killed", {
+	params ["_unit", "_killer", "_instigator", "_useEffects"];
+    _unit = _unit select 0;
+    DUMP("KILLED");
+    DUMP(_unit);
+    DUMP(group _unit);
+    DUMP(group CLib_Player);
+    DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
+    private _iconId = toLower format [QGVAR(IconId_Player_%1_%2), _unit, group _unit isEqualTo group CLib_Player];
+    [_iconId, "hoverin"] call CFUNC(removeMapGraphicsEventHandler);
+    [_iconId, "hoverout"] call CFUNC(removeMapGraphicsEventHandler);
+    [_iconId] call CFUNC(removeMapGraphicsGroup);
+    DUMP("ICON REMOVED BECAUSE KILLED: " + _iconId);
+    DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
+
+}] call CFUNC(addEventhandler);

--- a/addons/OPT/GPS/fn_clientInit.sqf
+++ b/addons/OPT/GPS/fn_clientInit.sqf
@@ -121,19 +121,31 @@ if (_units isEqualTo [] && _vehicles isEqualTo []) then {
 
 
 
-["Killed", {
+// ["MPKilled", {
+// 	params ["_unit", "_killer", "_instigator", "_useEffects"];
+//     _unit = _unit select 0;
+//     DUMP("KILLED");
+//     DUMP(_unit);
+//     DUMP(group _unit);
+//     DUMP(group CLib_Player);
+//     DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
+//     private _iconId = toLower format [QGVAR(IconId_Player_%1_%2), _unit, group _unit isEqualTo group CLib_Player];
+//     [_iconId] call CFUNC(removeMapGraphicsGroup);
+//     DUMP("ICON REMOVED BECAUSE KILLED: " + _iconId);
+//     DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
+
+// }] call CFUNC(addEventhandler);
+
+
+player addMPEventHandler ["MPKilled", {
 	params ["_unit", "_killer", "_instigator", "_useEffects"];
-    _unit = _unit select 0;
     DUMP("KILLED");
     DUMP(_unit);
     DUMP(group _unit);
     DUMP(group CLib_Player);
     DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
     private _iconId = toLower format [QGVAR(IconId_Player_%1_%2), _unit, group _unit isEqualTo group CLib_Player];
-    [_iconId, "hoverin"] call CFUNC(removeMapGraphicsEventHandler);
-    [_iconId, "hoverout"] call CFUNC(removeMapGraphicsEventHandler);
     [_iconId] call CFUNC(removeMapGraphicsGroup);
     DUMP("ICON REMOVED BECAUSE KILLED: " + _iconId);
     DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
-
-}] call CFUNC(addEventhandler);
+}];


### PR DESCRIPTION
Versuch, das Marker-Prob zu lösen.

Code funktioniert so (DUMP-vergleich, Mapgroup wird korrekt entfernt).

Es werden kurz nach dem Respawn trotzdem noch ein paar Fehler gespammt, das hört aber fix auf:

EDIT: `Zeile 9:57:01 (32947) [opt DUMP - GPS]: UNIT ICON ADDED: opt_gps_iconid_player_csat_gruppenfuehrer_3_true clib_fnc_localEvent>clib_fnc_stepStatemachine OPT\OPT\addons\OPT\gps\fn_clientInit.sqf:98`
und Zeile  `9:56:48 (32572) [opt DUMP - GPS]: ICON REMOVED BECAUSE KILLED: opt_gps_iconid_player_csat_gruppenfuehrer_3_true clib_fnc_localEvent>clib_fnc_localEvent OPT\OPT\addons\OPT\gps\fn_clientInit.sqf:135` sind die entscheidenden Punkte, an denen der Marker entfernt/geaddet wird.
```
 9:56:48 (32572) [opt DUMP - GPS]: KILLED clib_fnc_localEvent>clib_fnc_localEvent OPT\OPT\addons\OPT\gps\fn_clientInit.sqf:126
 9:56:48 (32572) [opt DUMP - GPS]: csat_gruppenfuehrer_3 clib_fnc_localEvent>clib_fnc_localEvent OPT\OPT\addons\OPT\gps\fn_clientInit.sqf:127
 9:56:48 (32572) [opt DUMP - GPS]: O Adler clib_fnc_localEvent>clib_fnc_localEvent OPT\OPT\addons\OPT\gps\fn_clientInit.sqf:128
 9:56:48 (32572) [opt DUMP - GPS]: O Adler clib_fnc_localEvent>clib_fnc_localEvent OPT\OPT\addons\OPT\gps\fn_clientInit.sqf:129
 9:56:48 (32572) [opt DUMP - GPS]: ["opt_gps_iconid_player_csat_gruppenfuehrer_3_true"] clib_fnc_localEvent>clib_fnc_localEvent OPT\OPT\addons\OPT\gps\fn_clientInit.sqf:130
 9:56:48 (32572) [opt DUMP - GPS]: ICON REMOVED BECAUSE KILLED: opt_gps_iconid_player_csat_gruppenfuehrer_3_true clib_fnc_localEvent>clib_fnc_localEvent OPT\OPT\addons\OPT\gps\fn_clientInit.sqf:135
 9:56:48 (32572) [opt DUMP - GPS]: [] clib_fnc_localEvent>clib_fnc_localEvent OPT\OPT\addons\OPT\gps\fn_clientInit.sqf:136
 9:56:48 (32572) [CLib DUMP - Events]: Local Event: Killed (1.9989013671875ms) sent from Local Called: [csat_gruppenfuehrer_3,csat_gruppenfuehrer_3,<NULL-object>,true] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:56:48 (32572) [CLib DUMP - Events]: Local Event: sideChanged (0ms) sent from Local Called: [CIV,EAST] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:56:49 (32573) [CLib DUMP - Events]: Local Event: currentWeaponChanged (0ms) sent from Local Called: ["","OPT_arifle_CTAR_blk_F"] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:56:49 (32573) [CLib DUMP - Events]: Local Event: playerInventoryChanged (0ms) sent from Local Called:  clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:56:49 (32573) [CLib DUMP - Events]: Local Event: cursorObjectChanged (0ms) sent from Local Called:  clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:56:49 (32574) [CLib DUMP - Events]: Local Event: AnimStateChanged (0ms) sent from Local Called: [csat_gruppenfuehrer_3,"unconscious"] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:56:49 (32574) [CLib DUMP - Events]: Local Event: entityCreated (0ms) sent from Local Called: 287e2258b80# 1815261: dummyweapon.p3d clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:56:49 (32574) [CLib DUMP - Events]: Local Event: cursorObjectChanged (0ms) sent from Local Called:  clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:56:49 (32575) [CLib DUMP - Events]: Local Event: playerInventoryChanged (0ms) sent from Local Called:  clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:56:49 (32589) [CLib DUMP - Events]: Local Event: AnimStateChanged (0ms) sent from Local Called: [csat_gruppenfuehrer_3,"deadstate"] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:56:59 (32779) [CLib DUMP - Events]: Local Event: cursorObjectChanged (0ms) sent from Local Called:  clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 (32926) [CLib DUMP - Events]: Local Event: visibleMapChanged (0ms) sent from Local Called: [true,false] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 Duplicate weapon Throw detected for OPT_CSAT_Gruppenfuehrer
 9:57:01 Duplicate weapon Put detected for OPT_CSAT_Gruppenfuehrer
 9:57:01 (32946) [CLib DUMP - Events]: Local Event: Respawn (0ms) sent from Local Called: [csat_gruppenfuehrer_3,csat_gruppenfuehrer_3] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 (32946) [CLib DUMP - Events]: Eventhandler Added To New Player: InventoryOpened clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_clientInit.sqf:93
 9:57:01 (32946) [CLib DUMP - Events]: Eventhandler Added To New Player: Killed clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_clientInit.sqf:93
 9:57:01 (32946) [CLib DUMP - Events]: Eventhandler Added To New Player: Respawn clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_clientInit.sqf:93
 9:57:01 (32946) [CLib DUMP - Events]: Eventhandler Added To New Player: AnimStateChanged clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_clientInit.sqf:93
 9:57:01 (32946) [CLib DUMP - Events]: Eventhandler Added To New Player: HandleDamage clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_clientInit.sqf:93
 9:57:01 (32946) [CLib DUMP - Events]: Local Event: playerChanged (0ms) sent from Local Called: [csat_gruppenfuehrer_3,csat_gruppenfuehrer_3] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 (32946) [CLib DUMP - Events]: Local Event: currentThrowableChanged (0ms) sent from Local Called: [["SmokeShell","SmokeShellMuzzle",[1.00104e+007,4]],["SmokeShell","SmokeShellMuzzle",[1.00102e+007,4]]] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 (32946) [CLib DUMP - Events]: Local Event: currentWeaponChanged (0ms) sent from Local Called: ["OPT_arifle_CTAR_blk_F",""] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 (32946) [CLib DUMP - Events]: Local Event: vehicleChanged (0ms) sent from Local Called: [csat_gruppenfuehrer_3,csat_gruppenfuehrer_3] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 (32946) [CLib DUMP - Events]: Local Event: sideChanged (0ms) sent from Local Called: [EAST,CIV] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 (32946) [CLib DUMP - Events]: Local Event: leaderChanged (0ms) sent from Local Called: [csat_gruppenfuehrer_3,csat_gruppenfuehrer_3] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 (32946) [CLib DUMP - Events]: Local Event: playerInventoryChanged (0ms) sent from Local Called:  clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 (32946) [CLib DUMP - Events]: Local Event: visibleGPSChanged (0ms) sent from Local Called: [false,true] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 (32946) [CLib DUMP - Events]: Local Event: cursorTargetChanged (0ms) sent from Local Called:  clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 (32946) [CLib DUMP - Events]: Local Event: groupUnitsChanged (0ms) sent from Local Called: [[csat_gruppenfuehrer_3],[csat_gruppenfuehrer_3]] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 (32947) [opt DUMP - GPS]: UNIT ICON ADDED: opt_gps_iconid_player_csat_gruppenfuehrer_3_true clib_fnc_localEvent>clib_fnc_stepStatemachine OPT\OPT\addons\OPT\gps\fn_clientInit.sqf:98
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 (32950) [CLib DUMP - Events]: Local Event: visibleMapChanged (0ms) sent from Local Called: [false,true] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 (32951) [CLib DUMP - Events]: Local Event: visibleGPSChanged (0ms) sent from Local Called: [true,false] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 (32951) [CLib DUMP - Events]: Local Event: cursorTargetChanged (0ms) sent from Local Called:  clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 (32964) [CLib DUMP - Events]: Local Event: visibleMapChanged (0ms) sent from Local Called: [true,false] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 (32964) [CLib DUMP - Events]: Local Event: cursorTargetChanged (0ms) sent from Local Called:  clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 WARNING: Function 'name' - csat_gruppenfuehrer_3 has no unit
 9:57:01  - network id 4:9
 9:57:01  - person [WGP]Senshi
 9:57:01  - dead
 9:57:01 (32983) [CLib DUMP - Events]: Local Event: visibleMapChanged (0ms) sent from Local Called: [false,true] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:02 (32998) [CLib DUMP - Events]: Local Event: visibleMapChanged (0ms) sent from Local Called: [true,false] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:02 (33017) [CLib DUMP - Events]: Local Event: visibleMapChanged (0ms) sent from Local Called: [false,true] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:02 (33018) [CLib DUMP - Events]: Local Event: cursorTargetChanged (0ms) sent from Local Called:  clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:14 (33429) [CLib DUMP - Events]: Local Event: visibleMapChanged (0ms) sent from Local Called: [true,false] clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48
 9:57:14 (33429) [CLib DUMP - Events]: Local Event: cursorTargetChanged (0ms) sent from Local Called:  clib_fnc_localEvent>clib_fnc_localEvent tc\CLib\addons\CLib\events\fn_localEvent.sqf:48

```