### PR TITLE
Umbau GPS System 

### DIFF
--- a/addons/OPT/GPS/fn_clientInit.sqf
+++ b/addons/OPT/GPS/fn_clientInit.sqf
@@ -52,4 +52,23 @@
 	// MiniGPS Steuerung Init
 	[] call FUNC(miniGPS);
 
+	// Kontinuierlicher Neustart des GPS System, Löschung alle Marker und Neuerstellung
+	[{
+		// alle Marker Löschen der Einheiten
+		allPlayers apply 
+		{
+			[_x] call FUNC(removeUnitFromGPS);
+		};
+
+		// Marker neu erstellen für alle
+		allPlayers apply 
+		{
+			if (CLib_Player != _x && [_x] call FUNC(isUnitVisible)) then 
+			{
+				[_x] call FUNC(addUnitToGPS);
+			};
+		};	
+
+    }, 60] call CFUNC(addPerFrameHandler);
+
 }] call CFUNC(addEventhandler);

--- a/addons/OPT/GPS/fn_clientInit.sqf
+++ b/addons/OPT/GPS/fn_clientInit.sqf
@@ -54,6 +54,17 @@
 
 	// Kontinuierlicher Neustart des GPS System, Löschung alle Marker und Neuerstellung
 	[{
+
+		// When BuildFlag != Version, the cache should be rebuilt automatically.
+		// The cache is what is actually drawn.
+		// The MapGraphicsGroup is what is currently registered to be drawn
+		// The MapGraphicsMapControls contain all controls where graphics should be drawn on
+		DUMP(clib_MapGraphics_MapGraphicsCacheBuildFlag);
+		DUMP(clib_MapGraphics_MapGraphicsCacheVersion);
+		DUMP(clib_MapGraphics_MapGraphicsCache);
+		DUMP(uinamespace getVariable "clib_mapgraphics_MapGraphicsMapControls");
+		DUMP(clib_MapGraphics_MapGraphicsGroup call clib_fnc_allVariables);
+
 		// alle Marker Löschen der Einheiten
 		allPlayers apply 
 		{
@@ -63,10 +74,7 @@
 		// Marker neu erstellen für alle
 		allPlayers apply 
 		{
-			if (CLib_Player != _x && [_x] call FUNC(isUnitVisible)) then 
-			{
-				[_x] call FUNC(addUnitToGPS);
-			};
+			[_x] call FUNC(addUnitToGPS);
 		};	
 
     }, 60] call CFUNC(addPerFrameHandler);

--- a/addons/OPT/GPS/fn_clientInit.sqf
+++ b/addons/OPT/GPS/fn_clientInit.sqf
@@ -46,6 +46,15 @@
 			((uiNamespace getVariable "RscCustomInfoMiniMap") displayCtrl 101) call CFUNC(registerMapControl);
 		};
 
+		if (!(isNull ((findDisplay 133) displayCtrl 101))) then
+		{
+			((findDisplay 133) displayCtrl 101) call CFUNC(registerMapControl);
+		};	
+
+		if (!(isNull ((findDisplay 133) displayCtrl 13301))) then
+		{
+			((findDisplay 133) displayCtrl 13301) call CFUNC(registerMapControl);
+		};	
 
     }, 1] call CFUNC(addPerFrameHandler);
 

--- a/addons/OPT/GPS/fn_clientInitEH.sqf
+++ b/addons/OPT/GPS/fn_clientInitEH.sqf
@@ -24,6 +24,7 @@
 
 #include "macros.hpp";
 
+/*
 ["Killed", {
     DUMP("KILLED");
     DUMP(_this);
@@ -85,7 +86,7 @@
     DUMP("ICON ADDED BECAUSE PLAYER JOINED: " + str _unit);
     DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
 }] call CFUNC(addEventhandler);
-
+*/
 
 // Revive Handlers
 [EVENT_MEDIC_UNCONSCIOUS, {

--- a/addons/OPT/GPS/fn_clientInitEH.sqf
+++ b/addons/OPT/GPS/fn_clientInitEH.sqf
@@ -24,70 +24,6 @@
 
 #include "macros.hpp";
 
-/*
-["Killed", {
-    DUMP("KILLED");
-    DUMP(_this);
-    params ["_unit", "_killer", "_instigator", "_useEffects"];
-    _unit = _unit select 0;
-    DUMP(_unit);
-    DUMP(group _unit);
-    DUMP(group CLib_Player);
-    DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
-    [[netId _unit], QFUNC(removeUnitFromGPS), -2] call CFUNC(remoteExec); // Trigger everywhere except server
-    DUMP("ICON REMOVED BECAUSE KILLED: " + str _unit);
-    DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
-
-}] call CFUNC(addEventhandler);
-
-
-["playerChanged", {
-    params ["_data", "_params"];
-    _data params ["_currentPlayer", "_oldPlayer"];
-
-    [{
-        private _currentPlayer = _this;
-        DUMP(_currentPlayer);
-        DUMP(alive _currentPlayer);
-        DUMP(alive CLib_Player);
-        DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
-        [[netid _currentPlayer], QFUNC(addUnitToGPS), -2] call CFUNC(remoteExec); // Trigger everywhere except server
-        DUMP("ICON ADDED BECAUSE PLAYERCHANGED: " + str _currentPlayer);
-        DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
-    }, _currentPlayer] call CLib_fnc_execNextFrame;
-}] call CFUNC(addEventhandler);
-
-["Respawn", {
-     DUMP("RESPAWN");
-     DUMP(_this);
-     params ["_data", "_params"];
-     _data params ["_unit"];
-     DUMP(_unit);
-     DUMP(alive _unit);
-     DUMP(alive CLib_Player);
-     {
-         DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
-         [[netid _unit], QFUNC(addUnitToGPS), -2] call CFUNC(remoteExec); // Trigger everywhere except server
-        DUMP("ICON ADDED BECAUSE RESPAWN: " + _iconId);
-        DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
-     } call CFUNC(execNextFrame);
-}] call CFUNC(addEventhandler);
-
-
-["playerJoined", {
-    DUMP("PLAYER JOINED");
-    DUMP(_this);
-    params ["_unit", ""];
-    DUMP(_unit);
-    DUMP(group _unit);
-    DUMP(group CLib_Player);
-    DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
-    [[netid _unit], QFUNC(addUnitToGPS), -2] call CFUNC(remoteExec); // Trigger everywhere except server
-    DUMP("ICON ADDED BECAUSE PLAYER JOINED: " + str _unit);
-    DUMP((CGVAR(MapGraphics_MapGraphicsGroup) call CFUNC(allVariables)) select {(_x find toLower QGVAR(IconId)) == 0});
-}] call CFUNC(addEventhandler);
-*/
-
 // Revive Handlers
 [EVENT_MEDIC_UNCONSCIOUS, {
     params ["_unit"];
@@ -119,17 +55,5 @@
 
 }] call CFUNC(addEventHandler);
 
-// "FAR_isStabilized" addPublicVariableEventHandler {
-//     private _unit = _this select 2;
-//     DUMP("FAR_IsStabilized has updated!");
-//     DUMP(_this);
-//     [str _unit] call FUNC(updateUnitIcon); // Trigger everywhere except server
-// };
 
-// "FAR_isUnconscious" addPublicVariableEventHandler {
-//     private _unit = _this select 2;
-//     DUMP("FAR_isUnconscious has updated!");
-//     DUMP(_this);
-//     [str _unit] call FUNC(updateUnitIcon); // Trigger everywhere except server
-// };
 

--- a/addons/OPT/modules.hpp
+++ b/addons/OPT/modules.hpp
@@ -10,7 +10,7 @@ class CfgCLibModules {
         MODULE(GPS) {
             dependency[] = {"CLib/PerFrame", "Clib/Events", "Clib/StateMachine", "Clib/MapGraphics", "Clib/RemoteExecution"};
             FNC(clientInit);
-            FNC(serverInit);
+            //FNC(serverInit);
             FNC(addUnitToGPS);
             FNC(removeUnitFromGPS);
             //FNC(addGroupToGPS);

--- a/addons/OPT/modules.hpp
+++ b/addons/OPT/modules.hpp
@@ -10,7 +10,7 @@ class CfgCLibModules {
         MODULE(GPS) {
             dependency[] = {"CLib/PerFrame", "Clib/Events", "Clib/StateMachine", "Clib/MapGraphics", "Clib/RemoteExecution"};
             FNC(clientInit);
-            //FNC(serverInit);
+            FNC(serverInit);
             FNC(addUnitToGPS);
             FNC(removeUnitFromGPS);
             //FNC(addGroupToGPS);


### PR DESCRIPTION
Umbau des GPS System um dem Absturz des System zu beheben.
Kontinuierlicher Neustart des GPS System, Löschung alle Marker und Neuerstellung der Marker danach für alle Spieler