### PR TITLE
Fix Feldreperatur, Räder werden vollständig repaiert

### DIFF
--- a/addons/OPT/FIELDREPAIR/fn_Init.sqf
+++ b/addons/OPT/FIELDREPAIR/fn_Init.sqf
@@ -25,5 +25,6 @@
 #include "macros.hpp"
 
 GVAR(repair_hps) = ["HitLFWheel", "HitLBWheel", "HitLMWheel", "HitLF2Wheel", "HitRFWheel", "HitRBWheel", "HitRMWheel","HitRF2Wheel", "HitEngine", "HitLTrack","HitRTrack", "HitHull", "HitWinch"] + ["HitEngine1", "HitEngine2", "HitEngine3", "HitFuel", "HitAvionics", "HitVRotor", "HitHRotor", "HitHydraulics", "HitGear", "HitTail", "HitPitotTube", "HitStaticPort"];
+GVAR(repair_Wheel) = ["HitLFWheel", "HitLBWheel", "HitLMWheel", "HitLF2Wheel", "HitRFWheel", "HitRBWheel", "HitRMWheel","HitRF2Wheel"];
 GVAR(hardRepairParts) = ["HitEngine", "HitLTrack", "HitRTrack", "HitHull"] + ["HitEngine1", "HitEngine2", "HitEngine3", "HitFuel", "HitAvionics", "HitHRotor", "HitHydraulics", "HitGear", "HitTail"];
 

--- a/addons/OPT/FIELDREPAIR/fn_partrepair.sqf
+++ b/addons/OPT/FIELDREPAIR/fn_partrepair.sqf
@@ -19,12 +19,12 @@ params [["_veh", objNull]];
 
 if (_veh isEqualTo objNull) exitWith {false}; 
 
-// repair each part if it is damaged more than 30%, but repair only 90%
+// repair each part if it is damaged more than 30%, repair 100%
 {
 	private _dmg = _veh getHitPointDamage _x;
 	if (not isNil {_dmg}) then {
 		if ( _dmg > 0.3 ) then {
-				_veh setHitPointDamage [_x, 0.1];
+				_veh setHitPointDamage [_x, 0.0];
 		};
 	};
 

--- a/addons/OPT/FIELDREPAIR/fn_partrepair.sqf
+++ b/addons/OPT/FIELDREPAIR/fn_partrepair.sqf
@@ -19,15 +19,24 @@ params [["_veh", objNull]];
 
 if (_veh isEqualTo objNull) exitWith {false}; 
 
-// repair each part if it is damaged more than 30%, repair 100%
+// Repaiert alles was beschädigt ist auf 90%, Räder werden auf 100% repaiert
 {
 	private _dmg = _veh getHitPointDamage _x;
-	if (not isNil {_dmg}) then {
-		if ( _dmg > 0.3 ) then {
-				_veh setHitPointDamage [_x, 0.0];
+	if (not isNil {_dmg}) then 
+	{
+		if ( _dmg > 0.3 ) then 
+		{
+			_veh setHitPointDamage [_x, 0.1];
 		};
 	};
 
 } foreach GVAR(repair_hps);
+
+// Räder von 90% auf 100% repaieren 
+{
+	_veh setHitPointDamage [_x, 0.0];
+
+} foreach GVAR(repair_Wheel);
+
 
 true


### PR DESCRIPTION
Räder werden zu 100% durch die Feldreparatur repariert, das einige Fahrzeuge trotz einer 90%  Reparatur sich zeitweilig dann verhalten als ob die Fahrzeuge eine Plattfuß hätten. Die Fahrzeuge lasse sich dann schwerer Lenken und fahren auch dann nur noch 1/4 der Geschwindigkeit. 
Die Fahrzeuge bekommen nun durch die Feldreparatur eine 100% der Räder womit sie wieder gut zu steuern sind. 