### PR TITLE
fix irritating label for CBA values

### DIFF
--- a/addons/OPT/SECTORCONTROL/fn_initCBASettings.sqf
+++ b/addons/OPT/SECTORCONTROL/fn_initCBASettings.sqf
@@ -168,7 +168,7 @@
 [
     QGVAR(nato_sektor), // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "EDITBOX", // setting type
-    "Angegriffene NATO Sektor", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "NATO Verteidigungssektor", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
     "OPT Sektorkontrolle", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     "0", // data for this setting: [min, max, default, number of shown trailing decimals]
     1, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
@@ -181,7 +181,7 @@
 [
     QGVAR(csat_sektor), // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "EDITBOX", // setting type
-    "Angegriffene CSAT Sektor", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "CSAT Verteidigungssektor", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
     "OPT Sektorkontrolle", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     "0", // data for this setting: [min, max, default, number of shown trailing decimals]
     1, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
@@ -194,7 +194,7 @@
 [
     QGVAR(aaf_sektor), // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
     "EDITBOX", // setting type
-    "Angegriffene AAF Sektor", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "AAF Verteidigungssektor", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
     "OPT Sektorkontrolle", // Pretty name of the category where the setting can be found. Can be stringtable entry.
     "0", // data for this setting: [min, max, default, number of shown trailing decimals]
     1, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer


### PR DESCRIPTION
"Angegriffene XX Sektor" was a very irritating label. Replaced it for a simpler to understand "Verteidigungssektor" label.