### PR TITLE
Erweiterung Sicherung für Autorepawn bei Revive

### DIFF
--- a/addons/OPT/REVIVE/fn_clientInitEH.sqf
+++ b/addons/OPT/REVIVE/fn_clientInitEH.sqf
@@ -121,6 +121,11 @@ DFUNC(playerHandleDamage) =
 		_unit setDamage GVAR(MAX_DAMAGE);		
 	};	
 
+	if (getDammage _unit >= GVAR(MAX_DAMAGE)) then 
+    { 
+		_unit setDamage GVAR(MAX_DAMAGE);		
+	};	
+
 	[FUNC(playercheckINCAPACITATED), 1,""] call CLib_fnc_wait;
 };
 


### PR DESCRIPTION
Weitere Absicherung die verhindern soll das der Spieler einen Schaden höher als 1.0 bekommt und so der Autorespwan eingeleitet wird. Der schaden wir gelöscht und auf den CBA Wert zurück gestellt. 