### PR TITLE
Disable GPS on map and reduced minimaldistance

### DIFF
--- a/addons/OPT/GPS/fn_clientInit.sqf
+++ b/addons/OPT/GPS/fn_clientInit.sqf
@@ -24,9 +24,7 @@
 #include "macros.hpp"
 
 ["missionStarted", {
- 
-[] call FUNC(gps);
-
-[] call FUNC(gps_Unconscious);
-
+	[] call FUNC(gps);
+	[] call FUNC(gps_Unconscious);
+	ace_maptools_mapGpsShow = false;	// disable GPS on map - can be reactivated by user via ace-menu
 }] call CFUNC(addEventhandler);

--- a/addons/OPT/SHOP/fn_clientInitcbaclassevents.sqf
+++ b/addons/OPT/SHOP/fn_clientInitcbaclassevents.sqf
@@ -113,7 +113,7 @@ This event happens every time a soldier enters a vehicle.
     turret: Array - turret path (since Arma 3 v1.36)
     */
 
-    // logge transport von Spielern, falls Spieler nicht Pilot und Strecke > 500m
+    // logge transport von Spielern
     _this call FUNC(writeTransportDistance);
 
 }] call CBA_fnc_addClassEventHandler;

--- a/addons/OPT/SHOP/fn_writetransportdistance.sqf
+++ b/addons/OPT/SHOP/fn_writetransportdistance.sqf
@@ -30,7 +30,7 @@ params [
    ["_unit", objNull, [objNull], 1]
 ];
 
-private _distanceFromBase = 1000;
+private _minDistance = 50;
 
 //if (_vec isEqualTo objNull or _unit isEqualTo objNull) exitWith{};
 
@@ -44,7 +44,7 @@ if (_condition) exitWith {};
 
 private _dis = (getPos _vec) distance2D (_unit getVariable QGVAR(transport_start_loc));
 
-if (_pos in ["cargo", "gunner"] and (_dis > _distanceFromBase)) then 
+if (_pos in ["cargo", "gunner"] and (_dis > _minDistance)) then 
 {
     // Log Flugdistanz
     ["Transport", "Fly", [getPlayerUID _unit, name _unit, side _unit, getPlayerUID _pilot, name _pilot, side _pilot, _dis]] call OPT_LOGGING_fnc_writelog;


### PR DESCRIPTION
- Mini-GPS auf Karte standardmäßig deaktiviert (ist eh nur im Weg - Kann vom User aber wieder aktiviert werden)
- Minimaldistanz für Transportlog von 1000 auf 50 Meter reduziert