### PR TITLE
Make submodule tracking the main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "dependencies/CLib"]
 	path = dependencies/CLib
 	url = https://github.com/OperationPandoraTrigger/CLib.git
+	branch = main


### PR DESCRIPTION
`dependencies/CLib` folgt jetzt dem (geforkten) main-branch.