### PR TITLE
Fix für Missions-Ende

### DIFF
--- a/addons/OPT/GELDZEIT/fn_frezztime.sqf
+++ b/addons/OPT/GELDZEIT/fn_frezztime.sqf
@@ -28,19 +28,9 @@
 */
 #include "macros.hpp"
 
-DFUNC(Player_freeze_time) = 
+// Spieler in der Freezetime einfrieren
+if (GVAR(GAMESTAGE) == GAMESTAGE_FREEZE) then 
 {
-    // gib Spieler frei
-    player enableSimulation true;
-};
-
-// friere Spieler, falls freezeTime aktiv
-if (!GVAR(Waffenruhestart)) then 
-{
-    // freeze Spieler zu Beginn
+    // Spieler zu Beginn einfrieren
     player enableSimulation false;
-
-    // warte OPT_PARAM_FREEZE_TIME
-    //[FUNC(Player_freeze_time), GVAR(FREEZETIME),""] call CLib_fnc_wait;
-    [FUNC(Player_freeze_time), {(GVAR(FreeztimeEnde))}, "Awesome Delay"] call CLib_fnc_waitUntil;
 };

--- a/addons/OPT/GELDZEIT/fn_serverInit.sqf
+++ b/addons/OPT/GELDZEIT/fn_serverInit.sqf
@@ -30,21 +30,13 @@ private _time = systemTime;
 ["Logging", "Start", [LOGGING_VERSION, OPT_GELDZEIT_Fraktionauswahl, format ["%1-%2-%3 %4:%5:%6", _time select 0, _time select 1, _time select 2, _time select 3, _time select 4, _time select 5]]] call OPT_LOGGING_fnc_writelog;
 ["Mission", "Load", [0, 0, 0, missionName]] call OPT_LOGGING_fnc_writelog;
 
-//Init Statussignale
-GVAR(FreeztimeEnde) = false;
-publicVariable QGVAR(FreeztimeEnde);
-
-GVAR(Waffenruhestart) = false;
-publicVariable QGVAR(Waffenruhestart);
-
-GVAR(Spielzeitstart) = false;
-publicVariable QGVAR(Spielzeitstart);
-
-GVAR(SpielzeitEnde) = false;
+GVAR(GAMESTAGE) = GAMESTAGE_FREEZE;
+publicVariable QGVAR(GAMESTAGE);
 
 GVAR(playerList) = [];
 
-["missionStarted", {
+["missionStarted",
+{
     GVAR(startTime) = serverTime;
     publicVariable QGVAR(startTime);
 
@@ -54,46 +46,68 @@ GVAR(playerList) = [];
 
     // Aktuellen Spielabschnitt setzen
     [{
-        private _timeElapsed = serverTime - GVAR(startTime); 
-
-        // Nach Ablauf der Freezetime die Waffenruhe auslösen
-        if (!GVAR(FreeztimeEnde) && serverTime > GVAR(Timestamp_Waffenruhestart)) then
+        switch (GVAR(GAMESTAGE)) do 
         {
-            GVAR(FreeztimeEnde) = true;
-            publicVariable QGVAR(FreeztimeEnde);
+            case GAMESTAGE_FREEZE: 
+            {
+                // Nach Ablauf der Freezetime die Waffenruhe auslösen
+                if (serverTime > GVAR(Timestamp_Waffenruhestart)) then
+                {
+                    GVAR(GAMESTAGE) = GAMESTAGE_TRUCE;
+                    publicVariable QGVAR(GAMESTAGE);
 
-            GVAR(Waffenruhestart) = true;
-            publicVariable QGVAR(Waffenruhestart);
+                    // Gefreezte Spieler auftauen
+                    {player enableSimulation true;} remoteExec ["call", -2];
 
-            // Logeintrag
-            ["Mission", "Truce", [0, 0, 0, missionName]] call OPT_LOGGING_fnc_writelog;
-        };
+                    // Logeintrag
+                    ["Mission", "Truce", [0, 0, 0, missionName]] call OPT_LOGGING_fnc_writelog;
+                };
+            };
 
-        // Nach Ablauf der Waffenruhe die Spielzeit auslösen
-        if (GVAR(Waffenruhestart) && !GVAR(Spielzeitstart) && serverTime > GVAR(Timestamp_Spielzeitstart)) then
-        {
-            GVAR(Spielzeitstart) = true;
-            publicVariable QGVAR(Spielzeitstart);
+            case GAMESTAGE_TRUCE: 
+            {
+                // Nach Ablauf der Waffenruhe die Spielzeit auslösen
+                if (serverTime > GVAR(Timestamp_Spielzeitstart)) then
+                {
+                    GVAR(GAMESTAGE) = GAMESTAGE_WAR;
+                    publicVariable QGVAR(GAMESTAGE);
 
-            // Missionsstart loggen
-            ["Mission", "Start", [0, 0, 0, missionName]] call OPT_LOGGING_fnc_writelog;
+                    // Missionsstart loggen
+                    ["Mission", "Start", [0, 0, 0, missionName]] call OPT_LOGGING_fnc_writelog;
 
-            // Nach Ablauf der Waffenruhe die Sektorenmarker von der Karte entfernen
-            [] call OPT_SECTORCONTROL_fnc_deletesectormarkers;
-        };
+                    // Nach Ablauf der Waffenruhe die Sektorenmarker von der Karte entfernen
+                    [] call OPT_SECTORCONTROL_fnc_deletesectormarkers;
+                };
+            };
 
-        // Nach Ablauf der Spielzeit das Ende auslösen
-        if (GVAR(Spielzeitstart) && !GVAR(SpielzeitEnde) && serverTime > GVAR(Timestamp_Spielzeitende)) then
-        {
-            GVAR(SpielzeitEnde) = true;
+            case GAMESTAGE_WAR: 
+            {
+                // Nach Ablauf der Spielzeit das Ende auslösen
+                if (serverTime > GVAR(Timestamp_Spielzeitende)) then
+                {
+                    GVAR(GAMESTAGE) = GAMESTAGE_END;
+                    publicVariable QGVAR(GAMESTAGE);
 
-            // Spielerliste loggen
-            [] call FUNC(writePlayerList);
+                    // Spielerliste loggen
+                    [] call FUNC(writePlayerList);
 
-            // Endpunktestand loggen
-            ["Mission", "End", [OPT_SECTORCONTROL_nato_points, OPT_SECTORCONTROL_csat_points, OPT_SECTORCONTROL_aaf_points, missionName]] call OPT_LOGGING_fnc_writelog;
+                    // Endpunktestand loggen
+                    ["Mission", "End", [OPT_SECTORCONTROL_nato_points, OPT_SECTORCONTROL_csat_points, OPT_SECTORCONTROL_aaf_points, missionName]] call OPT_LOGGING_fnc_writelog;
 
-            [EVENT_SPIELUHR_ENDBILDSCHIRM,[]] call CFUNC(globalEvent);
-        };
+                    [EVENT_SPIELUHR_ENDBILDSCHIRM,[]] call CFUNC(globalEvent);
+                };
+            };
+
+            case GAMESTAGE_END: 
+            {
+                // do nothing and watch people disconnecting...
+            };
+
+            default
+            {
+                GVAR(GAMESTAGE) = GAMESTAGE_FREEZE;
+                publicVariable QGVAR(GAMESTAGE);
+            };
+        }; 
     }, 1, _this] call CFUNC(addPerFrameHandler);
 }] call CFUNC(addEventhandler);

--- a/addons/OPT/HUD/fn_updatehud.sqf
+++ b/addons/OPT/HUD/fn_updatehud.sqf
@@ -43,7 +43,7 @@ disableSerialization;
 
         default 
         {
-            ERROR_LOG("Updatehud: Fehlerhafte Daten�bergabe - Keine Fraktionauswahl erkannt");
+            ERROR_LOG("Updatehud: Fehlerhafte Datenübergabe - Keine Fraktionauswahl erkannt");
         };
     };
 

--- a/addons/OPT/HUD/fn_updatehud.sqf
+++ b/addons/OPT/HUD/fn_updatehud.sqf
@@ -43,7 +43,7 @@ disableSerialization;
 
         default 
         {
-            ERROR_LOG("Updatehud: Fehlerhafte Datenübergabe - Keine Fraktionauswahl erkannt");
+            ERROR_LOG("Updatehud: Fehlerhafte Datenï¿½bergabe - Keine Fraktionauswahl erkannt");
         };
     };
 
@@ -81,7 +81,7 @@ disableSerialization;
 
         default 
         {
-            ERROR_LOG("Updatehud: Fehlerhafte Datenübergabe - Keine Fraktionauswahl erkannt");
+            ERROR_LOG("UpdateHUD: Fehlerhafte DatenÃ¼bergabe - Keine Fraktionauswahl erkannt");
         };
     };
 
@@ -94,11 +94,11 @@ disableSerialization;
     _control = _currentCutDisplay displayCtrl 5105;
 
     private "_timeStr";
-    private _timeElapsed = (serverTime - OPT_GELDZEIT_startTime);
+    private _timeElapsed = serverTime - OPT_GELDZEIT_startTime;
     private _playTime = OPT_GELDZEIT_PLAYTIME - _timeElapsed;
-    private _truceTime = (OPT_GELDZEIT_TRUCETIME + OPT_GELDZEIT_FREEZETIME) - _timeElapsed;
+    private _truceTime = OPT_GELDZEIT_TRUCETIME + OPT_GELDZEIT_FREEZETIME - _timeElapsed;
 
-    if (OPT_GELDZEIT_Spielzeitstart) then 
+    if (OPT_GELDZEIT_GAMESTAGE >= GAMESTAGE_WAR) then 
     {
         // Mission gestartet - Zeige verbleibende Spielzeit
         _timeLeft = [_playTime] call CBA_fnc_formatElapsedTime;

--- a/addons/OPT/HUD/fn_updatehud.sqf
+++ b/addons/OPT/HUD/fn_updatehud.sqf
@@ -1,5 +1,5 @@
 /**
-* Author: James
+* Author: James, form
 * script for updating HUD information each forEachMember
 *
 * Arguments:
@@ -16,9 +16,19 @@
 
 disableSerialization;
 
+// avoid CBA_fnc_formatElapsedTime because it shows "60" seconds from time to time...
+TimeToString =
+{
+    params ["_seconds"];
+    private _hours = floor (_seconds / 3600);
+    _seconds = _seconds - (_hours * 3600);
+    private _minutes = floor (_seconds / 60);
+    _seconds = _seconds - (_minutes * 60);
+    format ["%1:%2:%3", _hours, [_minutes, 2] call CBA_fnc_formatNumber, [floor _seconds , 2] call CBA_fnc_formatNumber];
+};
+
 //Anzeigen Steuerung im Dialog
 [{
-
     private _currentCutDisplay = uiNamespace getVariable "opt_hud_anzeige";      
     //--------------------- update players ------------------------------------------
     private _control = _currentCutDisplay displayCtrl 5101;
@@ -93,35 +103,37 @@ disableSerialization;
     //--------------------- update clock ---------------------------------------
     _control = _currentCutDisplay displayCtrl 5105;
 
-    private "_timeStr";
+    private _timeStr = "";
     private _timeElapsed = serverTime - OPT_GELDZEIT_startTime;
-    private _playTime = OPT_GELDZEIT_PLAYTIME - _timeElapsed;
-    private _truceTime = OPT_GELDZEIT_TRUCETIME + OPT_GELDZEIT_FREEZETIME - _timeElapsed;
 
     if (OPT_GELDZEIT_GAMESTAGE >= GAMESTAGE_WAR) then 
     {
         // Mission gestartet - Zeige verbleibende Spielzeit
-        _timeLeft = [_playTime] call CBA_fnc_formatElapsedTime;
+        private _playTime = OPT_GELDZEIT_PLAYTIME - _timeElapsed;
 
         if (_playTime > 0) then 
         {
-            _timeStr = format [MLOC(TIME_LEFT), _timeLeft];
+            _timeStr = format [MLOC(TIME_LEFT), [_playTime] call TimeToString];
             _control ctrlSetTextColor [0.7, 0.7, 0.7, 1];
         } 
         else
         {
             _timeStr = MLOC(TIME_END);
-            _control ctrlSetTextColor [1, 0, 0, 0.9];
+        };
+
+        // Färbe Uhr in den letzten 5 Minuten rot
+        if (_playTime < 300) then 
+        {
+            _control ctrlSetTextColor [0.9, 0.2, 0.2, 1];
         };
     } 
     else 
     {
         // Mission noch nicht gestartet - Zeige verbleibende Zeit der Waffenruhe
-        _timeLeft = [_truceTime] call CBA_fnc_formatElapsedTime;
-
+        private _truceTime = OPT_GELDZEIT_TRUCETIME + OPT_GELDZEIT_FREEZETIME - _timeElapsed;
         if (_truceTime > 0) then 
         {
-            _timeStr = format [MLOC(TIME_CEASEFIRE), _timeLeft];
+            _timeStr = format [MLOC(TIME_CEASEFIRE), [_truceTime] call TimeToString];
             _control ctrlSetTextColor [0.6, 0.1, 0, 1];
         } 
         else
@@ -133,12 +145,5 @@ disableSerialization;
 
     // Anzeige updaten
     _control ctrlSetText _timeStr;
-
-    // Färbe Uhr in den letzten 5 Minuten rot
-    if (_playTime < 300) then 
-    {
-        _control ctrlSetTextColor [0.9, 0.2, 0.2, 1];
-    };
-
     _control ctrlShow true;
 }, 1, _this] call CFUNC(addPerFrameHandler);

--- a/addons/OPT/SECTORCONTROL/fn_Punkte.sqf
+++ b/addons/OPT/SECTORCONTROL/fn_Punkte.sqf
@@ -23,7 +23,7 @@ GVAR(points_logtime) = 0;
 GVAR(Punktecount) = [
 {
     // Logge und übertrage Punktestand, solange Spiel noch läuft
-    if ((OPT_GELDZEIT_Spielzeitstart) and (OPT_GELDZEIT_PLAYTIME - (serverTime - OPT_GELDZEIT_startTime) > 0)) then
+    if ((OPT_GELDZEIT_GAMESTAGE == GAMESTAGE_WAR) and (OPT_GELDZEIT_PLAYTIME - (serverTime - OPT_GELDZEIT_startTime) > 0)) then
     {
         // Falls es einen Dominator gibt -> Erhöhe Punkte +1, ansonsten spätestens alls 60 Sekunden einen Logeintrag
         switch (GVAR(dominator)) do 

--- a/addons/OPT/SECTORCONTROL/fn_addflagmenu.sqf
+++ b/addons/OPT/SECTORCONTROL/fn_addflagmenu.sqf
@@ -39,7 +39,7 @@ if (typeOf player in GVAR(officer)) then
         true, 
         true, 
         "", 
-        "(OPT_GELDZEIT_GAMESTAGE <= GAMESTAGE_TRUCE)"
+        "(OPT_GELDZEIT_GAMESTAGE <= 1)"
     ];
 
     // inform player

--- a/addons/OPT/SECTORCONTROL/fn_addflagmenu.sqf
+++ b/addons/OPT/SECTORCONTROL/fn_addflagmenu.sqf
@@ -39,7 +39,7 @@ if (typeOf player in GVAR(officer)) then
         true, 
         true, 
         "", 
-        "OPT_GELDZEIT_GAMESTAGE <= GAMESTAGE_TRUCE"
+        "(OPT_GELDZEIT_GAMESTAGE <= GAMESTAGE_TRUCE)"
     ];
 
     // inform player

--- a/addons/OPT/SECTORCONTROL/fn_addflagmenu.sqf
+++ b/addons/OPT/SECTORCONTROL/fn_addflagmenu.sqf
@@ -16,7 +16,7 @@
 */
 #include "macros.hpp"
 
-if (OPT_GELDZEIT_Spielzeitstart) exitWith{};
+if (OPT_GELDZEIT_GAMESTAGE >= GAMESTAGE_WAR) exitWith{};
 
 GVAR(officer) =  
 [
@@ -39,7 +39,7 @@ if (typeOf player in GVAR(officer)) then
         true, 
         true, 
         "", 
-        "!OPT_GELDZEIT_Spielzeitstart"
+        "OPT_GELDZEIT_GAMESTAGE <= GAMESTAGE_TRUCE"
     ];
 
     // inform player

--- a/addons/OPT/SECTORCONTROL/fn_captureflagcondition.sqf
+++ b/addons/OPT/SECTORCONTROL/fn_captureflagcondition.sqf
@@ -34,7 +34,7 @@ if (_flag isEqualTo objNull or _unit isEqualTo objNull) exitWith{false};
 // in Restspielzeit gezogen werden 
 // nur von der anderen Seite
 vehicle _unit == _unit and
-OPT_GELDZEIT_Spielzeitstart and
+OPT_GELDZEIT_GAMESTAGE == GAMESTAGE_WAR and
 (_flag distance player) <= GVAR(flagDistanceToPlayer) and
 OPT_GELDZEIT_PLAYTIME - (serverTime - OPT_GELDZEIT_startTime) > 0 and
 (side _unit != _flag getVariable ['owner', sideUnknown])

--- a/addons/OPT/SECTORCONTROL/fn_serverInit.sqf
+++ b/addons/OPT/SECTORCONTROL/fn_serverInit.sqf
@@ -69,11 +69,11 @@ DFUNC(startflagsetup) =
     [sideUnknown, objNull] call FUNC(setFlagOwner);    
 };    
 
-["missionStarted", {
-
+["missionStarted",
+{
     // Finale Fahnenmasten und Markierungen setzen
     [] call FUNC(setupflagpoles);
-    [FUNC(startflagsetup), {OPT_GELDZEIT_Spielzeitstart}, "Awesome Delay"] call CLib_fnc_waitUntil;
+    [FUNC(startflagsetup), {OPT_GELDZEIT_GAMESTAGE == GAMESTAGE_WAR}, "Awesome Delay"] call CLib_fnc_waitUntil;
 }] call CFUNC(addEventhandler);
 
 // Sektorenmarker auf die Karte zeichnen sobald die Mission durchgeladen ist

--- a/addons/OPT/SECTORCONTROL/fn_serverInit.sqf
+++ b/addons/OPT/SECTORCONTROL/fn_serverInit.sqf
@@ -73,7 +73,7 @@ DFUNC(startflagsetup) =
 {
     // Finale Fahnenmasten und Markierungen setzen
     [] call FUNC(setupflagpoles);
-    [FUNC(startflagsetup), {OPT_GELDZEIT_GAMESTAGE == GAMESTAGE_WAR}, "Awesome Delay"] call CLib_fnc_waitUntil;
+    [FUNC(startflagsetup), {(OPT_GELDZEIT_GAMESTAGE == GAMESTAGE_WAR)}, "Awesome Delay"] call CLib_fnc_waitUntil;
 }] call CFUNC(addEventhandler);
 
 // Sektorenmarker auf die Karte zeichnen sobald die Mission durchgeladen ist

--- a/addons/OPT/SECTORCONTROL/fn_setupflag.sqf
+++ b/addons/OPT/SECTORCONTROL/fn_setupflag.sqf
@@ -135,7 +135,7 @@ Flaggen-Seite loggen
             true,                                                        // showWindow
             true,                                                        // hideOnUse 
             "",                                                          // shortcut
-            "(vehicle player == player and OPT_GELDZEIT_GAMESTAGE == GAMESTAGE_WAR and ((OPT_GELDZEIT_PLAYTIME - (serverTime - OPT_GELDZEIT_startTime)) > 0) and (playerside != _target getVariable 'owner'))",                              
+            "(vehicle player == player and (OPT_GELDZEIT_GAMESTAGE == GAMESTAGE_WAR) and ((OPT_GELDZEIT_PLAYTIME - (serverTime - OPT_GELDZEIT_startTime)) > 0) and (playerside != _target getVariable 'owner'))",                              
             GVAR(flagDistanceToPlayer)                                   // radius
         ]
     ] remoteExecCall ["addAction", -2, true];

--- a/addons/OPT/SECTORCONTROL/fn_setupflag.sqf
+++ b/addons/OPT/SECTORCONTROL/fn_setupflag.sqf
@@ -135,7 +135,7 @@ Flaggen-Seite loggen
             true,                                                        // showWindow
             true,                                                        // hideOnUse 
             "",                                                          // shortcut
-            "(vehicle player == player and (OPT_GELDZEIT_GAMESTAGE == GAMESTAGE_WAR) and ((OPT_GELDZEIT_PLAYTIME - (serverTime - OPT_GELDZEIT_startTime)) > 0) and (playerside != _target getVariable 'owner'))",                              
+            "(vehicle player == player and (OPT_GELDZEIT_GAMESTAGE == 2) and ((OPT_GELDZEIT_PLAYTIME - (serverTime - OPT_GELDZEIT_startTime)) > 0) and (playerside != _target getVariable 'owner'))",                              
             GVAR(flagDistanceToPlayer)                                   // radius
         ]
     ] remoteExecCall ["addAction", -2, true];

--- a/addons/OPT/SECTORCONTROL/fn_setupflag.sqf
+++ b/addons/OPT/SECTORCONTROL/fn_setupflag.sqf
@@ -135,7 +135,7 @@ Flaggen-Seite loggen
             true,                                                        // showWindow
             true,                                                        // hideOnUse 
             "",                                                          // shortcut
-            "(vehicle player == player and OPT_GELDZEIT_Spielzeitstart and ((OPT_GELDZEIT_PLAYTIME - (serverTime - OPT_GELDZEIT_startTime)) > 0) and (playerside != _target getVariable 'owner'))",                              
+            "(vehicle player == player and OPT_GELDZEIT_GAMESTAGE == GAMESTAGE_WAR and ((OPT_GELDZEIT_PLAYTIME - (serverTime - OPT_GELDZEIT_startTime)) > 0) and (playerside != _target getVariable 'owner'))",                              
             GVAR(flagDistanceToPlayer)                                   // radius
         ]
     ] remoteExecCall ["addAction", -2, true];

--- a/addons/OPT/SHOP/fn_handledeadvehicle.sqf
+++ b/addons/OPT/SHOP/fn_handledeadvehicle.sqf
@@ -34,7 +34,7 @@ switch OPT_GELDZEIT_Fraktionauswahl do
 {
         case "AAFvsCSAT":
         {
-            if (!(_vec isKindOf "CAManBase") and ((_vec distance2D (getmarkerPos "respawn_guerrila") < 200) or (_vec distance2D (getmarkerPos "respawn_east") < 200) or (_vec distance2D (getmarkerPos "CSAT_Basis2") < 200) or (_vec distance2D (getmarkerPos "AAF_Basis2") < 200))) then 
+            if (!(_vec isKindOf "CAManBase") and ((_vec distance2D (getmarkerPos "respawn_guerrila") < 200) or (_vec distance2D (getmarkerPos "respawn_east") < 200) or (_vec distance2D (getmarkerPos "Marker_CSAT_Basis2") < 200) or (_vec distance2D (getmarkerPos "Marker_AAF_Basis2") < 200))) then 
             {
                 [_vec] call 
                 {
@@ -51,7 +51,7 @@ switch OPT_GELDZEIT_Fraktionauswahl do
 
         case "NATOvsCSAT":
         {
-            if (!(_vec isKindOf "CAManBase") and ((_vec distance2D (getmarkerPos "respawn_west") < 200) or (_vec distance2D (getmarkerPos "respawn_east") < 200) or (_vec distance2D (getmarkerPos "CSAT_Basis2") < 200) or (_vec distance2D (getmarkerPos "NATO_Basis2") < 200))) then 
+            if (!(_vec isKindOf "CAManBase") and ((_vec distance2D (getmarkerPos "respawn_west") < 200) or (_vec distance2D (getmarkerPos "respawn_east") < 200) or (_vec distance2D (getmarkerPos "Marker_CSAT_Basis2") < 200) or (_vec distance2D (getmarkerPos "Marker_NATO_Basis2") < 200))) then 
             {
                 [_vec] call 
                 {
@@ -68,7 +68,7 @@ switch OPT_GELDZEIT_Fraktionauswahl do
 
         case "NATOvsAAF":
         {
-            if (!(_vec isKindOf "CAManBase") and ((_vec distance2D (getmarkerPos "respawn_west") < 200) or (_vec distance2D (getmarkerPos "respawn_guerrila") < 200) or (_vec distance2D (getmarkerPos "Nato_Basis2") < 200) or (_vec distance2D (getmarkerPos "AAF_Basis2") < 200))) then 
+            if (!(_vec isKindOf "CAManBase") and ((_vec distance2D (getmarkerPos "respawn_west") < 200) or (_vec distance2D (getmarkerPos "respawn_guerrila") < 200) or (_vec distance2D (getmarkerPos "Marker_NATO_Basis2") < 200) or (_vec distance2D (getmarkerPos "Marker_AAF_Basis2") < 200))) then 
             {
                 [_vec] call 
                 {
@@ -85,6 +85,6 @@ switch OPT_GELDZEIT_Fraktionauswahl do
 
            default 
         {
-            ERROR_LOG("handleDeadVehicle: Fehlerhafte Datenübergabe - Keine Fraktionauswahl erkannt");
+            ERROR_LOG("handleDeadVehicle: Fehlerhafte Datenï¿½bergabe - Keine Fraktionauswahl erkannt");
         };
 };

--- a/addons/OPT/SHOP/fn_handledeadvehicle.sqf
+++ b/addons/OPT/SHOP/fn_handledeadvehicle.sqf
@@ -85,6 +85,6 @@ switch OPT_GELDZEIT_Fraktionauswahl do
 
            default 
         {
-            ERROR_LOG("handleDeadVehicle: Fehlerhafte Daten�bergabe - Keine Fraktionauswahl erkannt");
+            ERROR_LOG("handleDeadVehicle: Fehlerhafte Datenübergabe - Keine Fraktionauswahl erkannt");
         };
 };

--- a/addons/OPT/macros.hpp
+++ b/addons/OPT/macros.hpp
@@ -6,7 +6,7 @@
 #define MAJOR 1
 #define MINOR 8
 #define PATCHLVL 9
-#define BUILD 110
+#define BUILD 122
 
 #ifdef VERSION
     #undef VERSION
@@ -121,3 +121,9 @@
     #define ASSERT_ALIVE(var)
     #define ASSERT_DEAD(var)
 #endif
+
+// Die 4 möglichen Spielabschnitte
+#define GAMESTAGE_FREEZE    0
+#define GAMESTAGE_TRUCE     1
+#define GAMESTAGE_WAR       2
+#define GAMESTAGE_END       3

--- a/addons/OPT/macros.hpp
+++ b/addons/OPT/macros.hpp
@@ -6,7 +6,7 @@
 #define MAJOR 1
 #define MINOR 8
 #define PATCHLVL 9
-#define BUILD 122
+#define BUILD 123
 
 #ifdef VERSION
     #undef VERSION


### PR DESCRIPTION
- Der nächste Spielabschnitt wird jetzt nicht mehr per `CLib_fnc_wait` mit einer festen Zeit abgewartet, sondern eine Statemachine in einem PFH entscheidet anhand des Timestamps wann der nächste Spielabschnitt startet.
- Wrack-Räum-Script repariert
- Im HUD angezeigter Countdown zeigt nun nicht mehr "60" Sekunden hinten an