### PR TITLE
Feindspieler Basis-Eintritt auf Kreismarker geändert

### DIFF
--- a/addons/main/RULES/fn_clientInit.sqf
+++ b/addons/main/RULES/fn_clientInit.sqf
@@ -185,7 +185,7 @@
                 case east:
                 {
                     [{
-                        if (((player distance independent_Basis_Teleport1) < MIN_DISTANCE_TO_ENEMYBASE) or ((player distance independent_Basis_Teleport2) < MIN_DISTANCE_TO_ENEMYBASE)) then
+                        if (((player distance2D getMarkerPos "AAF_T_Zone1") < MIN_DISTANCE_TO_ENEMYBASE) or ((player distance2D getMarkerPos "AAF_T_Zone2") < MIN_DISTANCE_TO_ENEMYBASE)) then
                         {
                             player setDamage 1;
                             [MLOC(BASE_DISTANCE)] remoteExecCall ["hint", -2]; 
@@ -196,7 +196,7 @@
                 case independent:
                 {
                     [{
-                        if (((player distance east_Basis_Teleport1) < MIN_DISTANCE_TO_ENEMYBASE) or ((player distance east_Basis_Teleport2) < MIN_DISTANCE_TO_ENEMYBASE)) then
+                        if (((player distance2D getMarkerPos "CSAT_T_Zone1") < MIN_DISTANCE_TO_ENEMYBASE) or ((player distance2D getMarkerPos "CSAT_T_Zone2") < MIN_DISTANCE_TO_ENEMYBASE)) then
                         {
                             player setDamage 1;
                             [MLOC(BASE_DISTANCE)] remoteExecCall ["hint", -2]; 
@@ -213,7 +213,7 @@
                 case east:
                 {
                     [{
-                        if (((player distance west_Basis_Teleport1) < MIN_DISTANCE_TO_ENEMYBASE) or ((player distance west_Basis_Teleport2) < MIN_DISTANCE_TO_ENEMYBASE)) then
+                        if (((player distance2D getMarkerPos "NATO_T_Zone1") < MIN_DISTANCE_TO_ENEMYBASE) or ((player distance2D getMarkerPos "NATO_T_Zone2") < MIN_DISTANCE_TO_ENEMYBASE)) then
                         {
                             player setDamage 1;
                             [MLOC(BASE_DISTANCE)] remoteExecCall ["hint", -2]; 
@@ -224,7 +224,7 @@
                 case west:
                 {
                     [{
-                        if (((player distance east_Basis_Teleport1) < MIN_DISTANCE_TO_ENEMYBASE) or ((player distance east_Basis_Teleport2) < MIN_DISTANCE_TO_ENEMYBASE)) then
+                        if (((player distance2D getMarkerPos "CSAT_T_Zone1") < MIN_DISTANCE_TO_ENEMYBASE) or ((player distance2D getMarkerPos "CSAT_T_Zone2") < MIN_DISTANCE_TO_ENEMYBASE)) then
                         {
                             player setDamage 1;
                             [MLOC(BASE_DISTANCE)] remoteExecCall ["hint", -2]; 
@@ -241,7 +241,7 @@
                 case independent:
                 {
                     [{
-                        if (((player distance west_Basis_Teleport1) < MIN_DISTANCE_TO_ENEMYBASE) or ((player distance west_Basis_Teleport2) < MIN_DISTANCE_TO_ENEMYBASE)) then
+                        if (((player distance2D getMarkerPos "NATO_T_Zone1") < MIN_DISTANCE_TO_ENEMYBASE) or ((player distance2D getMarkerPos "NATO_T_Zone2") < MIN_DISTANCE_TO_ENEMYBASE)) then
                         {
                             player setDamage 1;
                             [MLOC(BASE_DISTANCE)] remoteExecCall ["hint", -2]; 
@@ -252,7 +252,7 @@
                 case west:
                 {
                     [{
-                        if (((player distance independent_Basis_Teleport1) < MIN_DISTANCE_TO_ENEMYBASE) or ((player distance independent_Basis_Teleport2) < MIN_DISTANCE_TO_ENEMYBASE)) then
+                        if (((player distance2D getMarkerPos "AAF_T_Zone1") < MIN_DISTANCE_TO_ENEMYBASE) or ((player distance2D getMarkerPos "AAF_T_Zone2") < MIN_DISTANCE_TO_ENEMYBASE)) then
                         {
                             player setDamage 1;
                             [MLOC(BASE_DISTANCE)] remoteExecCall ["hint", -2]; 

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -2,7 +2,7 @@
 #define MAJOR 1
 #define MINOR 9
 #define PATCHLVL 1
-#define BUILD 13
+#define BUILD 15
 
 #ifdef VERSION
     #undef VERSION


### PR DESCRIPTION
Die Erkennung ob sich ein Feindspieler im Basis-Kreis befindet war vorher basierend auf der Beampad-Position, was eine leichte Differenz zum auf der Karte angezeigten Kreismarker ergab.