### PR TITLE
Reset TFAR encryption on respawn

### DIFF
--- a/addons/main/REVIVE/fn_clientInit.sqf
+++ b/addons/main/REVIVE/fn_clientInit.sqf
@@ -77,5 +77,6 @@ DFUNC(eigenversorgung) =
 
     [(typeOf player), 1, ["ACE_SelfActions"], GVAR(revive_Action_eigen)] call ace_interact_menu_fnc_addActionToClass;
 
+    // Spielerbeitritt loggen, bei Spielstart und wenn über die Lobby ein neuer Slot gewählt wird
     ["Player", "Joined", [getPlayerUID player, name player, side player]] remoteExecCall ["OPT_LOGGING_fnc_writelog", 2, false];
 }] call CFUNC(addEventhandler);

--- a/addons/main/REVIVE/fn_clientInitEH.sqf
+++ b/addons/main/REVIVE/fn_clientInitEH.sqf
@@ -84,15 +84,15 @@ DFUNC(isUnconscious) =
     {
         case west:
         {
-            _radio_key = "_bluefor2";
+            _radio_key = "_bluefor";
         };
         case east:
         { 
-            _radio_key = "_opfor2";
+            _radio_key = "_opfor";
         };
         case independent:
         { 
-            _radio_key = "_independent2";
+            _radio_key = "_independent";
         };
         default { };
     };

--- a/addons/main/REVIVE/fn_clientInitEH.sqf
+++ b/addons/main/REVIVE/fn_clientInitEH.sqf
@@ -55,7 +55,8 @@ DFUNC(isUnconscious) =
     };
 };
 
-["Respawn", {
+["Respawn",
+{
     params ["_data", "_args"];
     _data params ["_newPlayer", "_oldPlayer"];
     _oldPlayer removeEventHandler ["HandleDamage", GVAR(PLAYER_HANDLE_DAMAGE_EH_ID)];
@@ -74,7 +75,37 @@ DFUNC(isUnconscious) =
     OPT_REVIVE_unconsciousHandler = nil;
     OPT_REVIVE_respawnedHandler = nil;
     
-    1 enableChannel true;    
+    1 enableChannel true;
+
+    // TFAR Encryption beim Joinen neu setzen
+    private _radio_key = "";
+
+    switch (playerSide) do 
+    {
+        case west:
+        {
+            _radio_key = "_bluefor2";
+        };
+        case east:
+        { 
+            _radio_key = "_opfor2";
+        };
+        case independent:
+        { 
+            _radio_key = "_independent2";
+        };
+        default { };
+    };
+
+    if (call TFAR_fnc_haveSWRadio) then
+    {
+        [call TFAR_fnc_activeSwRadio, _radio_key] call TFAR_fnc_setSwRadioCode;
+    };
+
+    if (call TFAR_fnc_haveLRRadio) then
+    {
+        [call TFAR_fnc_activeLrRadio, _radio_key] call TFAR_fnc_setLrRadioCode;
+    };
 }] call CFUNC(addEventhandler);
 
 


### PR DESCRIPTION
Setzt beim Respawnen die TFAR-Verschlüsselung zurück. Könnte helfen falls zwischendurch komische Dinge passiert sind.