### PR TITLE
Fix GPS colorchange to local

### DIFF
--- a/addons/main/GPS/fn_gps.sqf
+++ b/addons/main/GPS/fn_gps.sqf
@@ -60,13 +60,13 @@ GVAR(markerOwn) setMarkerAlphaLocal 1;
             _markerAlive setMarkerAlphaLocal 0;
             _markerAlive setMarkerTypeLocal "loc_ViewTower"; // brauchbare Spielermarker: MemoryFragment, mil_triangle_noShadow, mil_start_noShadow, mil_arrow_noShadow, loc_ViewTower
             _markerAlive setMarkerSizeLocal [1.2, 1.2];
-            _markerAlive setMarkerColor "ColorWhite";
+            _markerAlive setMarkerColorLocal "ColorWhite";
 
             createMarkerLocal [_markerDead, _playerVehicle];
             _markerDead setMarkerAlphaLocal 0;
             _markerDead setMarkerTypeLocal "loc_Hospital";  // brauchbare Todesmarker: loc_Hospital, KIA
             _markerDead setMarkerSizeLocal [0.8, 0.8];
-            _markerDead setMarkerColor "ColorRed";
+            _markerDead setMarkerColorLocal "ColorRed";
         };
 
         // Zeit des letzten Updates speichern (für späteren Cleanup)

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -2,7 +2,7 @@
 #define MAJOR 1
 #define MINOR 9
 #define PATCHLVL 1
-#define BUILD 49
+#define BUILD 50
 
 #ifdef VERSION
     #undef VERSION


### PR DESCRIPTION
Die Farbänderung in der einmaligen Marker-Initialisierung wurde versehentlich zum Server gebroadcasted. Zum Glück ist dabei nichts kaputt gegangen 😅
Danke an @DragonGER für die Meldung!