### PR TITLE
Timestamping von Markern aktivieren als default

### DIFF
--- a/addons/main/GPS/fn_clientInit.sqf
+++ b/addons/main/GPS/fn_clientInit.sqf
@@ -31,4 +31,5 @@
     };
 
     ace_maptools_mapGpsShow = false;    // disable GPS on map - can be reactivated by user via ace-menu
+    uiNamespace setVariable ["ace_markers_timestampChecked", true];    // enable ACE marker timestamping - can be disabled by user via checkbox
 }] call CFUNC(addEventhandler);


### PR DESCRIPTION
Nach der Planungsphase auf der Karte, beim Durchstarten in die Waffenruhe, wird die Checkbox zum Timestampen der eigenen Marker bei jedem Spieler gesetzt. Kann im laufe der Schlacht von jedem Spieler auch wieder zurückgesetzt werden.