### PR TITLE
Teleport Verbesserungen

### DIFF
--- a/addons/main/CfgCLibLocalisation.hpp
+++ b/addons/main/CfgCLibLocalisation.hpp
@@ -76,6 +76,12 @@ class CfgCLibLocalisation
                 English = "Select position to teleport with left click.";
                 German = "Position zum Teleport mit Linksklick auswählen.";
             };
+            
+            class TELEPORT_FAIL
+            {
+                English = "Teleporting failed. Too much trees in that area.";
+                German = "Teleport gescheitert. Zuviele Bäume in der Umgebung.";
+            };
         };
 
         class RULES

--- a/addons/main/SECTORCONTROL/fn_teleport.sqf
+++ b/addons/main/SECTORCONTROL/fn_teleport.sqf
@@ -14,8 +14,8 @@
 */
 #include "macros.hpp"
 
-private _txt = MLOC(TELEPORT_MSG);
 private _header = MLOC(TELEPORT_MSG_HEADER);
+private _txt = MLOC(TELEPORT_MSG);
 hint format ["%1\n\n%2", _header, _txt];
 
 openMap true;
@@ -28,34 +28,58 @@ openMap true;
     shift: Boolean - true if Shift key was pressed (same as _shift param)
     */
 
-    // Teleport für Boote auf Wasserhöhe + 0,2m
-    if (surfaceIsWater _pos) then
+    private _newPos = [0, 0, 0];
+    private _fail = false;
+
+    // Teleport auf Wasser oder Brücken
+    if ((surfaceIsWater _pos) and !(vehicle player isKindOf "Air")) then
     {
-        vehicle player setPosASL [(random 100) + 1000, (random 100) + 1000, (random 100) + 1000];
-        vehicle player setVectorUp [0, 0, 1];
-        vehicle player setPosASL (_pos vectorAdd [0, 0, 0.2]);
+        // Höhe der neuen Position von +2500 bis -2500 auf Intersection (Brücke) checken - für die neue Zielhöhe
+        _pos = lineIntersectsSurfaces [_pos vectorAdd [0, 0, 2500], _pos vectorAdd [0, 0, -2500]] select 0 select 0;
+        // Zielhöhe niemals unterhalb der Wasseroberfläche
+        if ((_pos select 2) < 0) then
+        {
+            _pos set [2, 0];
+        };
+        _newPos = _pos vectorAdd [0, 0, 0.2];
     }
+    // Teleport auf normales Gelände
     else
     {
-        // Höhe der neuen Position von +5000 bis -5000 auf Intersection checken - für die neue Zielhöhe
-        _pos set [2, 5000];
-        _pos = lineIntersectsSurfaces [_pos, _pos vectorAdd [0, 0, -10000]] select 0 select 0 vectorAdd [0, 0, 0.1];
+        // Höhe der neuen Position von +4000 bis -1000 auf Intersection checken - für die neue Zielhöhe
+        _pos = lineIntersectsSurfaces [_pos vectorAdd [0, 0, 4000], _pos vectorAdd [0, 0, -1000]] select 0 select 0;
 
         // fliegendes Luftfahrzeug? -> teleport in selber höhe zum grund (+20m)
         private _playerHeight = getPosASL vehicle player select 2;
-        private _playerSurfaceHeight = lineIntersectsSurfaces [getPosASL vehicle player, (getposASL vehicle player) vectorAdd [0, 0, -10000], vehicle player] select 0 select 0 select 2;
+        private _playerSurfaceHeight = lineIntersectsSurfaces [getPosASL vehicle player, (getposASL vehicle player) vectorAdd [0, 0, -5000], vehicle player] select 0 select 0 select 2;
         private _heightAboveGround = _playerHeight - _playerSurfaceHeight;
         if ((vehicle player isKindOf "Air") and (_heightAboveGround > 2)) then
         {
-            vehicle player setPosASL (_pos vectorAdd [0, 0, _heightAboveGround + 20]);
+            _newPos = _pos vectorAdd [0, 0, _heightAboveGround + 20];
         }
         else
         {
-            // sonst normaler teleport
-            vehicle player setPosASL _pos;
+            // sonst normaler Teleport, aber Abbruch bei Bäumen am Zielort
+            if (count nearestTerrainObjects [_pos select [0, 2], ["TREE", "SMALL TREE"], 10] > 0) then
+            {
+                private _header = MLOC(TELEPORT_MSG_HEADER);
+                private _txt = MLOC(TELEPORT_FAIL);
+                hint format ["%1\n\n%2", _header, _txt];
+                _fail = true;
+            };
+
+            _newPos = _pos vectorAdd [0, 0, 0.2];
         };
     };
-    
-    [QGVAR(onMapSingleClick), "onMapSingleClick"] call BIS_fnc_removeStackedEventHandler;
-    openMap false;
+
+    if !(_fail) then
+    {
+        // Den Teleport durchführen. (Zuerst in die Luft zum sicheren Ausrichten und dann final platzieren)
+        vehicle player setPosASL (_newPos vectorAdd [0, 0, 100]);
+        vehicle player setVectorUp surfaceNormal _newPos;
+        vehicle player setPosASL _newPos;
+
+        [QGVAR(onMapSingleClick), "onMapSingleClick"] call BIS_fnc_removeStackedEventHandler;
+        openMap false;
+    };
 }] call BIS_fnc_addStackedEventHandler;


### PR DESCRIPTION
- Warnung bei Bäumen im Zielgebiet (90% Detektionswahrscheinlichkeit, 10% fallen leider durchs Raster)
- Teleport auf Brücken klappt nun
- Helikopterflughöhe wird nicht mehr auf Null gesetzt wenn Teleport über Wasser
- Fahrzeuge werden korrekt an die Bodenbeschaffenheit ausgerichtet