### PR TITLE
Diverse Dinge

### DIFF
--- a/addons/main/CfgCLibLocalisation.hpp
+++ b/addons/main/CfgCLibLocalisation.hpp
@@ -79,8 +79,8 @@ class CfgCLibLocalisation
             
             class TELEPORT_FAIL
             {
-                English = "Teleporting failed. The chosen destination is too unsafe.";
-                German = "Teleport gescheitert. Der gewählte Zielort ist zu unsicher.";
+                English = "Teleporting failed. There is not enough space at the selected destination.";
+                German = "Teleport gescheitert. Am gewählten Ziel ist nicht genügend Platz vorhanden.";
             };
         };
 

--- a/addons/main/CfgCLibLocalisation.hpp
+++ b/addons/main/CfgCLibLocalisation.hpp
@@ -444,21 +444,31 @@ class CfgCLibLocalisation
                 English = "Beam to other base";
                 German = "Beam zur anderen Basis";
             };
+
+            class BEAM_BUSY
+            {
+                English = "Unfortunately, the target position is currently occupied.";
+                German = "Die Zielposition ist derzeit leider belegt.";
+            };
+
             class HAFTLADUNG
             {
                 English = "Attach explosive charge";
                 German = "Sprengladung anbringen";
             };
+
             class HAFTLADUNGNOBOMBE
             {
                 English = "no explosive charge ready to be attached";
                 German = "keine Sprengladung bereit zum anbringen";
             };
+
             class HAFTLADUNGNOVEH
             {
                 English = "no vehicle ready to mount";
                 German = "keine Fahrzeug bereit zum anbringen";
             };
+
             class HAFTLADUNGATTACH
             {
                 English = "Explosive charge attached to vehicle";

--- a/addons/main/CfgCLibLocalisation.hpp
+++ b/addons/main/CfgCLibLocalisation.hpp
@@ -79,8 +79,8 @@ class CfgCLibLocalisation
             
             class TELEPORT_FAIL
             {
-                English = "Teleporting failed. Too much trees in that area.";
-                German = "Teleport gescheitert. Zuviele Bäume in der Umgebung.";
+                English = "Teleporting failed. The chosen destination is too unsafe.";
+                German = "Teleport gescheitert. Der gewählte Zielort ist zu unsicher.";
             };
         };
 

--- a/addons/main/GELDZEIT/fn_beam.sqf
+++ b/addons/main/GELDZEIT/fn_beam.sqf
@@ -29,7 +29,7 @@
 #include "macros.hpp"
 
 // Minimalentfernung zum Beam-Platz
-#define MIN_DISTANCE_TO_BEAMSPOT 20
+#define MIN_DISTANCE_TO_BEAMSPOT 10
 
 private _Basis = objNull;
 

--- a/addons/main/GELDZEIT/fn_beam.sqf
+++ b/addons/main/GELDZEIT/fn_beam.sqf
@@ -112,12 +112,7 @@ switch GVAR(Fraktionauswahl) do
 
 if !(isNull _Basis) then
 {
-    (["Basis"] call BIS_fnc_rscLayer) cutText ["Teleport...", "BLACK OUT", 3]; // fade out in black
-    // beam player
-    private _TempLogic = "Land_HelipadEmpty_F" createvehicle [(getPos _Basis select 0) - 20 * sin(random 360), (getPos _Basis select 1) - 20 * cos(random 360)];
-    vehicle player setPosASL (getPosASL _TempLogic vectorAdd [0, 0, 10]);
-    vehicle player setVectorUp surfaceNormal position _TempLogic;
-    vehicle player setPosASL (getPosASL _TempLogic vectorAdd [0, 0, 0.2]);
-    deleteVehicle _TempLogic;
-    (["Basis"] call BIS_fnc_rscLayer) cutText ["", "BLACK IN", 3];
+    // Beam-Auftrag an den Server weiterleiten
+    GVAR(BEAMJOB) = [player, _Basis];
+    publicVariableServer QGVAR(BEAMJOB);
 };

--- a/addons/main/GELDZEIT/fn_clientInitcbaclassevents.sqf
+++ b/addons/main/GELDZEIT/fn_clientInitcbaclassevents.sqf
@@ -1,5 +1,5 @@
 /**
-* Author: James
+* Author: Lord
 * initialize CBA class EH
 *
 * Arguments:
@@ -14,22 +14,18 @@
 */
 #include "macros.hpp"
 
-// Haftladungen (aber nicht auf der Livonia-Karte!)
-if (worldName != "Enoch") then
+// Haftladungen
+["LandVehicle", "init", 
 {
-    ["LandVehicle", "init", 
-    {
-        params ["_vec"];
-
-        _vec addAction [
-            format["<t color=""#f0f24e"">%1</t>", MLOC(HAFTLADUNG)], 
-            {[_this select 0] call FUNC(haftladungen)},
-            [], 
-            -1, 
-            false, 
-            true, 
-            '',
-            "_veh = vehicle _this; ((alive _target) and (speed _veh < 3) and (_veh distance _target) < 8 and vehicle player == player)"
-        ];
-    }, nil, nil, true] call CBA_fnc_addClassEventHandler;
-};
+    params ["_veh"];
+    _veh addAction [
+        format["<t color=""#f0f24e"">%1</t>", MLOC(HAFTLADUNG)], 
+        {[_this select 0] call FUNC(haftladungen)},
+        [], 
+        -1, 
+        false, 
+        true, 
+        '',
+        "_veh = vehicle _this; ((alive _target) and (speed _veh < 3) and (_veh distance _target) < 8 and vehicle player == player)"
+    ];
+}, nil, nil, true] call CBA_fnc_addClassEventHandler;

--- a/addons/main/GELDZEIT/fn_serverInit.sqf
+++ b/addons/main/GELDZEIT/fn_serverInit.sqf
@@ -151,12 +151,26 @@ QGVAR(BEAMJOB) addPublicVariableEventHandler
         if ((count _freiePads) > 0) then 
         {
             // Beamen
-            private _velocity = velocityModelSpace vehicle _player;
             {cutText ["Teleport...", "BLACK OUT", 0.1];} remoteExec ["call", _player];
+            private _velocity = velocityModelSpace vehicle _player;
+            private _playerHeight = getPosASL vehicle _player select 2;
+            private _playerSurfaceHeight = lineIntersectsSurfaces [getPosASL vehicle _player, (getposASL vehicle _player) vectorAdd [0, 0, -5000], vehicle _player] select 0 select 0 select 2;
+            private _heightAboveGround = _playerHeight - _playerSurfaceHeight;
+
             vehicle _player setPosASL (getPosASL _destination vectorAdd [0, 0, 1000]);
-            vehicle _player setVectorUp vectorUp _destination;
             vehicle _player setdir getdir _destination;
-            vehicle _player setPosASL (getPosASL _destination vectorAdd [0, 0, 0.2]);
+            
+            if ((vehicle _player isKindOf "Air") && (_heightAboveGround > 2)) then
+            {
+                vehicle _player setVectorUp [0, 0, 1];
+                vehicle _player setPosASL (getPosASL _destination vectorAdd [0, 0, _heightAboveGround + 20]);
+            }
+            else
+            {
+                vehicle _player setVectorUp vectorUp _destination;
+                vehicle _player setPosASL (getPosASL _destination vectorAdd [0, 0, 0.2]);
+            };
+    
             [vehicle _player, _velocity] remoteExec ["setVelocityModelSpace", _player];
             {cutText ["Teleport...", "BLACK IN", 0.5];} remoteExec ["call", _player];
         }

--- a/addons/main/GELDZEIT/fn_serverInit.sqf
+++ b/addons/main/GELDZEIT/fn_serverInit.sqf
@@ -44,6 +44,13 @@ GVAR(playerList) = [];
     GVAR(Timestamp_Spielzeitstart) = GVAR(startTime) + GVAR(FREEZETIME) + GVAR(TRUCETIME);
     GVAR(Timestamp_Spielzeitende) = GVAR(startTime) + GVAR(PLAYTIME);   // Freeze- & Trucetime zählt zur Spielzeit dazu!
 
+    // DynamicSimulation
+    enableDynamicSimulationSystem true;
+    "Group" setDynamicSimulationDistance 250;
+    "Vehicle" setDynamicSimulationDistance 200;
+    "EmptyVehicle" setDynamicSimulationDistance 150;
+    "Prop" setDynamicSimulationDistance 50;
+
     // Aktuellen Spielabschnitt setzen
     [{
         switch (GVAR(GAMESTAGE)) do 

--- a/addons/main/GELDZEIT/fn_serverInit.sqf
+++ b/addons/main/GELDZEIT/fn_serverInit.sqf
@@ -151,18 +151,20 @@ QGVAR(BEAMJOB) addPublicVariableEventHandler
         if ((count _freiePads) > 0) then 
         {
             // Beamen
+            private _velocity = velocityModelSpace vehicle _player;
             {cutText ["Teleport...", "BLACK OUT", 0.1];} remoteExec ["call", _player];
             vehicle _player setPosASL (getPosASL _destination vectorAdd [0, 0, 1000]);
             vehicle _player setVectorUp vectorUp _destination;
             vehicle _player setdir getdir _destination;
             vehicle _player setPosASL (getPosASL _destination vectorAdd [0, 0, 0.2]);
+            [vehicle _player, _velocity] remoteExec ["setVelocityModelSpace", _player];
             {cutText ["Teleport...", "BLACK IN", 0.5];} remoteExec ["call", _player];
         }
         else
         {
             // Das Ziel ist belegt
             {
-                hint "BEAM\n\nDie Zielposition ist derzeit leider belegt.";
+                hint format ["%1\n\n%2", MLOC(BEAM), MLOC(BEAM_BUSY)];
                 playSound "additemok";
             } remoteExec ["call", _player];
         };

--- a/addons/main/GELDZEIT/fn_serverInit.sqf
+++ b/addons/main/GELDZEIT/fn_serverInit.sqf
@@ -121,3 +121,43 @@ GVAR(playerList) = [];
         }; 
     }, 1, _this] call CFUNC(addPerFrameHandler);
 }] call CFUNC(addEventhandler);
+
+// Beam-System (Serverseitiger Teil)
+GVAR(BEAMJOBS) = [];
+GVAR(BEAMJOB) = [];
+publicVariable QGVAR(BEAMJOB);
+
+QGVAR(BEAMJOB) addPublicVariableEventHandler
+{
+    ["DEBUG", "BEAM", ["EH fired.", _this]] call OPT_LOGGING_fnc_writelog;
+
+    GVAR(BEAMJOBS) pushBackUnique GVAR(BEAMJOB);
+    while {count GVAR(BEAMJOBS) > 0} do
+    {
+        // Ersten Job aus dem Array ziehen
+        private _beamjob = GVAR(BEAMJOBS) deleteAt 0;   // FIFO
+        private _player = _beamjob select 0;
+        private _destination = _beamjob select 1;
+
+        // Checken ob das Ziel frei ist
+        private _freiePads = [[_destination], 15] call OPT_SHOP_fnc_checkpad;
+        if ((count _freiePads) > 0) then 
+        {
+            // Beamen
+            {cutText ["Teleport...", "BLACK OUT", 0.1];} remoteExec ["call", _player];
+            vehicle _player setPosASL (getPosASL _destination vectorAdd [0, 0, 1000]);
+            vehicle _player setVectorUp vectorUp _destination;
+            vehicle _player setdir getdir _destination;
+            vehicle _player setPosASL (getPosASL _destination vectorAdd [0, 0, 0.2]);
+            {cutText ["Teleport...", "BLACK IN", 0.5];} remoteExec ["call", _player];
+        }
+        else
+        {
+            // Das Ziel ist belegt
+            {
+                hint "BEAM\n\nDie Zielposition ist derzeit leider belegt.";
+                playSound "additemok";
+            } remoteExec ["call", _player];
+        };
+    };
+};

--- a/addons/main/GELDZEIT/fn_serverInit.sqf
+++ b/addons/main/GELDZEIT/fn_serverInit.sqf
@@ -136,8 +136,6 @@ publicVariable QGVAR(BEAMJOB);
 
 QGVAR(BEAMJOB) addPublicVariableEventHandler
 {
-    ["DEBUG", "BEAM", ["EH fired.", _this]] call OPT_LOGGING_fnc_writelog;
-
     GVAR(BEAMJOBS) pushBackUnique GVAR(BEAMJOB);
     while {count GVAR(BEAMJOBS) > 0} do
     {

--- a/addons/main/REVIVE/fn_clientInitEH.sqf
+++ b/addons/main/REVIVE/fn_clientInitEH.sqf
@@ -105,6 +105,9 @@ DFUNC(isUnconscious) =
     {
         [call TFAR_fnc_activeLrRadio, _radio_key] call TFAR_fnc_setLrRadioCode;
     };
+
+    // Shop Dialoge freigeben
+    OPT_SHOP_LOCK = false;
 }] call CFUNC(addEventhandler);
 
 

--- a/addons/main/RULES/fn_clientInit.sqf
+++ b/addons/main/RULES/fn_clientInit.sqf
@@ -62,18 +62,26 @@
             params ["_unit", "_pos", "_veh", "_turret"];
             private _pos2 = assignedVehicleRole _unit select 0;
 
-            if (typeOf _veh in GVAR(pilot_vehicles) && !(typeOf _unit in GVAR(pilots) + GVAR(jetpilots)) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
+            if (typeOf _veh in GVAR(choppers) && !(typeOf _unit in GVAR(pilots)) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
             {
                 _unit action ["GetOut", _veh];
-                private _txt = MLOC(SLOT_LOCK_PILOT);
+                _txt = MLOC(SLOT_LOCK_PILOT);
                 private _header = MLOC(SLOT_LOCK);
                 hint format ["%1\n\n%2", _header, _txt];
             };
 
-            if (typeOf _veh in GVAR(jetpilot_vehicles) && !(typeOf _unit in GVAR(jetpilots)) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
+            if (typeOf _veh in GVAR(planes) && !(typeOf _unit in (GVAR(pilots) + GVAR(jetpilots))) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
             {
                 _unit action ["GetOut", _veh];
-                private _txt = MLOC(SLOT_LOCK_PILOT);
+                _txt = MLOC(SLOT_LOCK_PILOT);
+                private _header = MLOC(SLOT_LOCK);
+                hint format ["%1\n\n%2", _header, _txt];
+            };
+
+            if (typeOf _veh in GVAR(jets) && !(typeOf _unit in GVAR(jetpilots)) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
+            {
+                _unit action ["GetOut", _veh];
+                _txt = MLOC(SLOT_LOCK_PILOT);
                 private _header = MLOC(SLOT_LOCK);
                 hint format ["%1\n\n%2", _header, _txt];
             };
@@ -81,7 +89,7 @@
             if ((typeOf _veh in GVAR(crew_vehicles) || _veh isKindOf "Tank") && !(typeOf _unit in GVAR(crew)) && _pos2 in GVAR(blockedVehiclePositions_veh)) then 
             {
                 _unit action ["GetOut", _veh];
-                private _txt = MLOC(SLOT_LOCK_CREW);
+                _txt = MLOC(SLOT_LOCK_CREW);
                 private _header = MLOC(SLOT_LOCK);
                 hint format ["%1\n\n%2", _header, _txt];
             };
@@ -98,7 +106,7 @@
             params ["_unit", "_unit2", "_veh"];
             private _pos2 = assignedVehicleRole _unit select 0;
 
-            if (typeOf _veh in GVAR(pilot_vehicles) && !(typeOf _unit in GVAR(pilots) + GVAR(jetpilots)) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
+            if (typeOf _veh in GVAR(choppers) && !(typeOf _unit in GVAR(pilots)) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
             {
                 _unit action ["GetOut", _veh];
                 _txt = MLOC(SLOT_LOCK_PILOT);
@@ -106,7 +114,15 @@
                 hint format ["%1\n\n%2", _header, _txt];
             };
 
-            if (typeOf _veh in GVAR(jetpilot_vehicles) && !(typeOf _unit in GVAR(jetpilots)) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
+            if (typeOf _veh in GVAR(planes) && !(typeOf _unit in (GVAR(pilots) + GVAR(jetpilots))) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
+            {
+                _unit action ["GetOut", _veh];
+                _txt = MLOC(SLOT_LOCK_PILOT);
+                private _header = MLOC(SLOT_LOCK);
+                hint format ["%1\n\n%2", _header, _txt];
+            };
+
+            if (typeOf _veh in GVAR(jets) && !(typeOf _unit in GVAR(jetpilots)) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
             {
                 _unit action ["GetOut", _veh];
                 _txt = MLOC(SLOT_LOCK_PILOT);
@@ -129,7 +145,7 @@
             private _pos = getPos player;
             private _posX = _pos select 0;
             private _posY = _pos select 1;
-            if (((_posX < 0) || (_posX > _mapSize) || (_posY < 0) || (_posY > _mapSize)) && !(typeOf vehicle player in GVAR(jetpilot_vehicles))) then
+            if (((_posX < 0) || (_posX > _mapSize) || (_posY < 0) || (_posY > _mapSize)) && !(typeOf vehicle player in (GVAR(planes) + GVAR(jets)))) then
             {
                 ["Cheat", "OutOfMap", [getPlayerUID player, name player, side player, _pos, typeOf vehicle player]] remoteExecCall ["OPT_LOGGING_fnc_writelog", 2, false];
                 player setDamage 1;

--- a/addons/main/RULES/fn_clientInit.sqf
+++ b/addons/main/RULES/fn_clientInit.sqf
@@ -65,7 +65,7 @@
             if (typeOf _veh in GVAR(choppers) && !(typeOf _unit in GVAR(pilots)) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
             {
                 _unit action ["GetOut", _veh];
-                _txt = MLOC(SLOT_LOCK_PILOT);
+                private _txt = MLOC(SLOT_LOCK_PILOT);
                 private _header = MLOC(SLOT_LOCK);
                 hint format ["%1\n\n%2", _header, _txt];
             };
@@ -73,7 +73,7 @@
             if (typeOf _veh in GVAR(planes) && !(typeOf _unit in (GVAR(pilots) + GVAR(jetpilots))) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
             {
                 _unit action ["GetOut", _veh];
-                _txt = MLOC(SLOT_LOCK_PILOT);
+                private _txt = MLOC(SLOT_LOCK_PILOT);
                 private _header = MLOC(SLOT_LOCK);
                 hint format ["%1\n\n%2", _header, _txt];
             };
@@ -81,7 +81,7 @@
             if (typeOf _veh in GVAR(jets) && !(typeOf _unit in GVAR(jetpilots)) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
             {
                 _unit action ["GetOut", _veh];
-                _txt = MLOC(SLOT_LOCK_PILOT);
+                private _txt = MLOC(SLOT_LOCK_PILOT);
                 private _header = MLOC(SLOT_LOCK);
                 hint format ["%1\n\n%2", _header, _txt];
             };
@@ -89,7 +89,7 @@
             if ((typeOf _veh in GVAR(crew_vehicles) || _veh isKindOf "Tank") && !(typeOf _unit in GVAR(crew)) && _pos2 in GVAR(blockedVehiclePositions_veh)) then 
             {
                 _unit action ["GetOut", _veh];
-                _txt = MLOC(SLOT_LOCK_CREW);
+                private _txt = MLOC(SLOT_LOCK_CREW);
                 private _header = MLOC(SLOT_LOCK);
                 hint format ["%1\n\n%2", _header, _txt];
             };
@@ -109,7 +109,7 @@
             if (typeOf _veh in GVAR(choppers) && !(typeOf _unit in GVAR(pilots)) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
             {
                 _unit action ["GetOut", _veh];
-                _txt = MLOC(SLOT_LOCK_PILOT);
+                private _txt = MLOC(SLOT_LOCK_PILOT);
                 private _header = MLOC(SLOT_LOCK);
                 hint format ["%1\n\n%2", _header, _txt];
             };
@@ -117,7 +117,7 @@
             if (typeOf _veh in GVAR(planes) && !(typeOf _unit in (GVAR(pilots) + GVAR(jetpilots))) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
             {
                 _unit action ["GetOut", _veh];
-                _txt = MLOC(SLOT_LOCK_PILOT);
+                private _txt = MLOC(SLOT_LOCK_PILOT);
                 private _header = MLOC(SLOT_LOCK);
                 hint format ["%1\n\n%2", _header, _txt];
             };
@@ -125,7 +125,7 @@
             if (typeOf _veh in GVAR(jets) && !(typeOf _unit in GVAR(jetpilots)) && _pos2 in GVAR(blockedVehiclePositions_air) && !(typeOf _veh in ["Steerable_Parachute_F", "NonSteerable_Parachute_F"])) then 
             {
                 _unit action ["GetOut", _veh];
-                _txt = MLOC(SLOT_LOCK_PILOT);
+                private _txt = MLOC(SLOT_LOCK_PILOT);
                 private _header = MLOC(SLOT_LOCK);
                 hint format ["%1\n\n%2", _header, _txt];
             };
@@ -133,7 +133,7 @@
             if ((typeOf _veh in GVAR(crew_vehicles) || _veh isKindOf "Tank") && !(typeOf _unit in GVAR(crew)) && _pos2 in GVAR(blockedVehiclePositions_veh)) then 
             {
                 _unit action ["GetOut", _veh];
-                _txt = MLOC(SLOT_LOCK_CREW);
+                private _txt = MLOC(SLOT_LOCK_CREW);
                 private _header = MLOC(SLOT_LOCK);
                 hint format ["%1\n\n%2", _header, _txt];
             };

--- a/addons/main/RULES/fn_clientInit.sqf
+++ b/addons/main/RULES/fn_clientInit.sqf
@@ -149,7 +149,7 @@
             {
                 ["Cheat", "OutOfMap", [getPlayerUID player, name player, side player, _pos, typeOf vehicle player]] remoteExecCall ["OPT_LOGGING_fnc_writelog", 2, false];
                 player setDamage 1;
-                [MLOC(PLAYER_OUT_OF_MAP)] remoteExecCall ["hint", -2]; 
+                {hint format ["%1", MLOC(PLAYER_OUT_OF_MAP)];} remoteExec ["call", -2];
             };
         }, INTERVAL_DISTANCE_CHECK] call CFUNC(addPerFrameHandler);
 
@@ -167,7 +167,7 @@
                             {
                                 ["Cheat", "KillZone", [getPlayerUID player, name player, side player, position player, typeOf vehicle player]] remoteExecCall ["OPT_LOGGING_fnc_writelog", 2, false];
                                 player setDamage 1;
-                                [MLOC(BASE_DISTANCE)] remoteExecCall ["hint", -2]; 
+                                {hint format ["%1", MLOC(BASE_DISTANCE)];} remoteExec ["call", -2];
                             };
                         }, INTERVAL_DISTANCE_CHECK] call CFUNC(addPerFrameHandler);
                     };
@@ -179,7 +179,7 @@
                             {
                                 ["Cheat", "KillZone", [getPlayerUID player, name player, side player, position player, typeOf vehicle player]] remoteExecCall ["OPT_LOGGING_fnc_writelog", 2, false];
                                 player setDamage 1;
-                                [MLOC(BASE_DISTANCE)] remoteExecCall ["hint", -2]; 
+                                {hint format ["%1", MLOC(BASE_DISTANCE)];} remoteExec ["call", -2];
                             };
                         }, INTERVAL_DISTANCE_CHECK] call CFUNC(addPerFrameHandler);
                     };
@@ -197,7 +197,7 @@
                             {
                                 ["Cheat", "KillZone", [getPlayerUID player, name player, side player, position player, typeOf vehicle player]] remoteExecCall ["OPT_LOGGING_fnc_writelog", 2, false];
                                 player setDamage 1;
-                                [MLOC(BASE_DISTANCE)] remoteExecCall ["hint", -2]; 
+                                {hint format ["%1", MLOC(BASE_DISTANCE)];} remoteExec ["call", -2];
                             };
                         }, INTERVAL_DISTANCE_CHECK] call CFUNC(addPerFrameHandler);
                     };
@@ -209,7 +209,7 @@
                             {
                                 ["Cheat", "KillZone", [getPlayerUID player, name player, side player, position player, typeOf vehicle player]] remoteExecCall ["OPT_LOGGING_fnc_writelog", 2, false];
                                 player setDamage 1;
-                                [MLOC(BASE_DISTANCE)] remoteExecCall ["hint", -2]; 
+                                {hint format ["%1", MLOC(BASE_DISTANCE)];} remoteExec ["call", -2];
                             };
                         }, INTERVAL_DISTANCE_CHECK] call CFUNC(addPerFrameHandler);
                     };
@@ -227,7 +227,7 @@
                             {
                                 ["Cheat", "KillZone", [getPlayerUID player, name player, side player, position player, typeOf vehicle player]] remoteExecCall ["OPT_LOGGING_fnc_writelog", 2, false];
                                 player setDamage 1;
-                                [MLOC(BASE_DISTANCE)] remoteExecCall ["hint", -2]; 
+                                {hint format ["%1", MLOC(BASE_DISTANCE)];} remoteExec ["call", -2];
                             };
                         }, INTERVAL_DISTANCE_CHECK] call CFUNC(addPerFrameHandler);
                     };
@@ -239,7 +239,7 @@
                             {
                                 ["Cheat", "KillZone", [getPlayerUID player, name player, side player, position player, typeOf vehicle player]] remoteExecCall ["OPT_LOGGING_fnc_writelog", 2, false];
                                 player setDamage 1;
-                                [MLOC(BASE_DISTANCE)] remoteExecCall ["hint", -2]; 
+                                {hint format ["%1", MLOC(BASE_DISTANCE)];} remoteExec ["call", -2];
                             };
                         }, INTERVAL_DISTANCE_CHECK] call CFUNC(addPerFrameHandler);
                     };

--- a/addons/main/RULES/fn_setup_classnames.sqf
+++ b/addons/main/RULES/fn_setup_classnames.sqf
@@ -64,7 +64,7 @@ GVAR(jetpilots) =
     "OPT_CSAT_Pilot_jet"
 ];
 
-GVAR(pilot_vehicles) = 
+GVAR(choppers) = 
 [
     "OPT4_B_Heli_light_03_green_F",                    // WY-55 Hellcat (Unbewaffnet)
     "OPT_B_Heli_Light_01_F",                    // MH-9 Hummingbird
@@ -139,23 +139,30 @@ GVAR(pilot_vehicles) =
     "OPT_CUP_B_UH1D_armed_GER_KSK",         // UH-1D
     "OPT_CUP_B_CH53E_USMC",                 // CH-53G Super Stallion
     "OPT_CUP_B_AH64D_DL_USA",               // AH-64
+
+    // CSAT - CUP
+    "OPT_CUP_O_SA330_Puma_HC1_BAF",         // SA-330 Puma
+    "OPT_CUP_O_Ka60_Grey_RU",               // KA-60 Katsaka
+    "OPT_CUP_O_Merlin_HC3_GB",              // Merlin HC3A
+    "OPT_CUP_O_Mi24_V_Dynamic_RU"          // MI-24V
+];
+
+GVAR(planes) = 
+[
+    // NATO - CUP
     "OPT_CUP_C_Cessna_172_CIV_BLUE",        // Cessna
     "OPT_CUP_C_AN2_CIV",                    // Antonov An-2
     "OPT_CUP_C_DC3_ChernAvia_CIV",          // Li-2
     "OPT_CUP_B_C130J_USMC",                 // C130J
 
     // CSAT - CUP
-    "OPT_CUP_O_SA330_Puma_HC1_BAF",         // SA-330 Puma
-    "OPT_CUP_O_Ka60_Grey_RU",               // KA-60 Katsaka
-    "OPT_CUP_O_Merlin_HC3_GB",              // Merlin HC3A
-    "OPT_CUP_O_Mi24_V_Dynamic_RU",          // MI-24V
     "OPT_CUP_C_Cessna_172_CIV_GREEN",       // Cessna
     "OPT_CUP_O_AN2_TK",                     // Antonov An-2
     "OPT_CUP_O_C47_SLA",                    // Li-2
     "OPT_CUP_O_C130J_TKA"                   // C130J
 ];
 
-GVAR(jetpilot_vehicles) = 
+GVAR(jets) = 
 [
     // NATO - CUP
     "OPT_CUP_B_L39_CZ_GREY",                // L-39AZ

--- a/addons/main/SECTORCONTROL/fn_clientInit.sqf
+++ b/addons/main/SECTORCONTROL/fn_clientInit.sqf
@@ -74,4 +74,16 @@
     }; 
     [FUNC(SetupSpectatorPositions), 2, ""] call CLib_fnc_wait;   
 */
+
+    // Beim Karte-Schließen den Teleport-EH entfernen, damit man später aus versehen nicht teleportieren kann
+    (finddisplay 12) displayAddEventhandler["KeyDown", 
+    { 
+        params ["_display", "_key"]; 
+        // ESC oder M gedrückt?
+        if (_key == 1 || _key == 50) then
+        {
+            [QGVAR(onMapSingleClick), "onMapSingleClick"] call BIS_fnc_removeStackedEventHandler;
+            openMap false;
+        };
+    }]; 
 }] call CFUNC(addEventhandler);

--- a/addons/main/SECTORCONTROL/fn_clientinitplayereh.sqf
+++ b/addons/main/SECTORCONTROL/fn_clientinitplayereh.sqf
@@ -66,22 +66,10 @@ if (GVAR(trainingon)) then
     // Teleport funktion
     player addAction [("<t color=""#f0bfbfbf"">" + ("Teleport") + "</t>"), {[] call FUNC(teleport)}, [], 0, false, true, '', "alive _target"];
     
-    // Virtuelles Arsenal (aber nicht auf der Livonia-Karte!)
-    if (worldName != "Enoch") then
-    {
-        player addAction ["<t color='#FF0000'>Virtual Arsenal</t>", {["Open", true] spawn BIS_fnc_arsenal;}, [], 5, false, true];
-    };
-
     ["Respawn",
     {
         // Teleport funktion
         player addAction [("<t color=""#f0bfbfbf"">" + ("Teleport") + "</t>"), {[] call FUNC(teleport)}, [], 0, false, true, '', "alive _target"];
-
-        // Virtuelles Arsenal (aber nicht auf der Livonia-Karte!)
-        if (worldName != "Enoch") then
-        {
-            player addAction ["<t color='#FF0000'>Virtual Arsenal</t>", {["Open", true] spawn BIS_fnc_arsenal;}, [], 5, false, true];
-        };
     }] call CFUNC(addEventhandler);
 };
 

--- a/addons/main/SECTORCONTROL/fn_setupsectors.sqf
+++ b/addons/main/SECTORCONTROL/fn_setupsectors.sqf
@@ -727,7 +727,8 @@ switch OPT_GELDZEIT_Fraktionauswahl do
 } forEach GVAR(Side1SectorMarkers);
 
 // Karten Umrandung
-[[[0, worldSize], [worldSize, worldSize]], "ColorBlack", 16, "MapBorder1"] call FUNC(drawline);
-[[[worldSize, worldSize], [worldSize, 0]], "ColorBlack", 16, "MapBorder2"] call FUNC(drawline);
-[[[worldSize, 0], [0, 0]], "ColorBlack", 16, "MapBorder3"] call FUNC(drawline);
-[[[0, 0], [0, worldSize]], "ColorBlack", 16, "MapBorder4"] call FUNC(drawline);
+private _worldsize = (worldName call BIS_fnc_mapSize);
+[[[0, _worldsize], [_worldsize, _worldsize]], "ColorRed", 24, "MapBorder1"] call FUNC(drawline);
+[[[_worldsize, _worldsize], [_worldsize, 0]], "ColorRed", 24, "MapBorder2"] call FUNC(drawline);
+[[[_worldsize, 0], [0, 0]], "ColorRed", 24, "MapBorder3"] call FUNC(drawline);
+[[[0, 0], [0, _worldsize]], "ColorRed", 24, "MapBorder4"] call FUNC(drawline);

--- a/addons/main/SECTORCONTROL/fn_teleport.sqf
+++ b/addons/main/SECTORCONTROL/fn_teleport.sqf
@@ -63,8 +63,9 @@ openMap true;
             private _size = (sizeOf typeOf (vehicle player)) / 2;
             _newPos = [_pos, 0, 20, _size, 0, 1] call BIS_fnc_findSafePos;
 
-            // Abbruch, wenn kein sicherer Ort gefunden wird. (BIS_fnc_findSafePos gibt dann die Kartenmitte zurück. Die Rundung ist nötig da worldSize nicht ganz exakt ist)
-            if ((_newPos select 0) == (round (worldSize / 10) * 5) && (_newPos select 1) == (round (worldSize / 10) * 5)) then
+            // Abbruch, wenn kein sicherer Ort gefunden wird. (BIS_fnc_findSafePos gibt dann die Kartenmitte zurück)
+            private _worldsize = (worldName call BIS_fnc_mapSize);
+            if ((_newPos select 0) == (_worldsize / 2) && (_newPos select 1) == (_worldsize / 2)) then
             {
                 private _header = MLOC(TELEPORT_MSG_HEADER);
                 private _txt = MLOC(TELEPORT_FAIL);

--- a/addons/main/SECTORCONTROL/fn_teleport.sqf
+++ b/addons/main/SECTORCONTROL/fn_teleport.sqf
@@ -59,8 +59,11 @@ openMap true;
         }
         else
         {
-            // sonst normaler Teleport, aber Abbruch bei Bäumen am Zielort
-            if (count nearestTerrainObjects [_pos select [0, 2], ["TREE", "SMALL TREE"], 10] > 0) then
+            // sonst normaler Teleport, aber sicheren Ort suchen
+            _newPos = [_pos, 0, 20, 3, 0, 1] call BIS_fnc_findSafePos;
+
+            // Abbruch, wenn kein sicherer Ort gefunden wird. (BIS_fnc_findSafePos gibt dann die Kartenmitte zurück. Die Rundung ist nötig da worldSize nicht ganz exakt ist)
+            if ((_newPos select 0) == (round (worldSize / 10) * 5) && (_newPos select 1) == (round (worldSize / 10) * 5)) then
             {
                 private _header = MLOC(TELEPORT_MSG_HEADER);
                 private _txt = MLOC(TELEPORT_FAIL);
@@ -69,7 +72,8 @@ openMap true;
                 _fail = true;
             };
 
-            _newPos = _pos vectorAdd [0, 0, 0.2];
+            _newPos set [2, 0];
+            _newPos = AGLToASL _newPos;
         };
     };
 

--- a/addons/main/SECTORCONTROL/fn_teleport.sqf
+++ b/addons/main/SECTORCONTROL/fn_teleport.sqf
@@ -60,7 +60,8 @@ openMap true;
         else
         {
             // sonst normaler Teleport, aber sicheren Ort suchen
-            _newPos = [_pos, 0, 20, 3, 0, 1] call BIS_fnc_findSafePos;
+            private _size = (sizeOf typeOf (vehicle player)) / 2;
+            _newPos = [_pos, 0, 20, _size, 0, 1] call BIS_fnc_findSafePos;
 
             // Abbruch, wenn kein sicherer Ort gefunden wird. (BIS_fnc_findSafePos gibt dann die Kartenmitte zurück. Die Rundung ist nötig da worldSize nicht ganz exakt ist)
             if ((_newPos select 0) == (round (worldSize / 10) * 5) && (_newPos select 1) == (round (worldSize / 10) * 5)) then

--- a/addons/main/SECTORCONTROL/fn_teleport.sqf
+++ b/addons/main/SECTORCONTROL/fn_teleport.sqf
@@ -77,6 +77,7 @@ openMap true;
     {
         // Den Teleport durchführen. (Zuerst in die Luft zum sicheren Ausrichten und dann final platzieren)
         vehicle player setPosASL (_newPos vectorAdd [0, 0, 100]);
+        vehicle player setVelocity [0, 0, 0];
         vehicle player setVectorUp surfaceNormal _newPos;
         vehicle player setPosASL _newPos;
 

--- a/addons/main/SHOP/fn_clientInit.sqf
+++ b/addons/main/SHOP/fn_clientInit.sqf
@@ -28,7 +28,7 @@
 DUMP("Successfully loaded the OPT/Shop module on the client");
 
 // Innerhalb dieser Entfernung zum Shop-Schild kann der Spieler den Shop via Hotkey öffnen
-#define MAX_DISTANCE_TO_SHOP 6
+#define MAX_DISTANCE_TO_SHOP 3
 
 GVAR(Daten_send) = false;
 GVAR(eventArgs) = [];
@@ -81,255 +81,256 @@ GVAR(eventArgs) = [];
 
 ["missionStarted", 
 {
+    GVAR(LOCK) = false;
     switch OPT_GELDZEIT_Fraktionauswahl do 
     {
-            case "AAFvsCSAT":
-            {
-                //AddAction für Dialog öffnen
-                east_shop_air addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["choppers"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                independent_shop_air addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["choppers"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+        case "AAFvsCSAT":
+        {
+            //AddAction für Dialog öffnen
+            east_shop_air addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["choppers"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            independent_shop_air addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["choppers"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
 
-                east_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                independent_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-                civ1_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                civ2_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            east_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            independent_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+            civ1_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            civ2_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
 
-                east_shop_veh addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_GROUND)], {[EVENT_SHOP_KAUF_ONLOAD,["vehicles"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                independent_shop_veh addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_GROUND)], {[EVENT_SHOP_KAUF_ONLOAD,["vehicles"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+            east_shop_veh addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_GROUND)], {[EVENT_SHOP_KAUF_ONLOAD,["vehicles"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            independent_shop_veh addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_GROUND)], {[EVENT_SHOP_KAUF_ONLOAD,["vehicles"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
 
-                east_shop_sup addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_EQUIPMENT)], {[EVENT_SHOP_KAUF_ONLOAD,["supplies"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                independent_shop_sup addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_EQUIPMENT)], {[EVENT_SHOP_KAUF_ONLOAD,["supplies"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+            east_shop_sup addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_EQUIPMENT)], {[EVENT_SHOP_KAUF_ONLOAD,["supplies"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            independent_shop_sup addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_EQUIPMENT)], {[EVENT_SHOP_KAUF_ONLOAD,["supplies"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
 
-                east_shop_sea addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SEA)], {[EVENT_SHOP_KAUF_ONLOAD,["sea"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                independent_shop_sea addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SEA)], {[EVENT_SHOP_KAUF_ONLOAD,["sea"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+            east_shop_sea addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SEA)], {[EVENT_SHOP_KAUF_ONLOAD,["sea"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            independent_shop_sea addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SEA)], {[EVENT_SHOP_KAUF_ONLOAD,["sea"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
 
-                east_shop_verkauf addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SELL)], {[EVENT_SHOP_VERKAUF_ORDER,["sell"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                independent_shop_verkauf addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SELL)], {[EVENT_SHOP_VERKAUF_ORDER,["sell"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+            east_shop_verkauf addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SELL)], {[EVENT_SHOP_VERKAUF_ORDER,["sell"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            independent_shop_verkauf addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SELL)], {[EVENT_SHOP_VERKAUF_ORDER,["sell"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
 
-                //Shop Dialog öffnen
-                /*
-                * https://cbateam.github.io/CBA_A3/docs/files/keybinding/fnc_addKeybind-sqf.html
-                */
-                [
-                    "OPT", 
-                    "OPT Shop System", 
-                    ["Shop-Dialog öffnen", "Öffnet den Shop-Dialog im Fahnenbereich."], 
+            //Shop Dialog öffnen
+            /*
+            * https://cbateam.github.io/CBA_A3/docs/files/keybinding/fnc_addKeybind-sqf.html
+            */
+            [
+                "OPT", 
+                "OPT Shop System", 
+                ["Shop-Dialog öffnen", "Öffnet den Shop-Dialog im Fahnenbereich."], 
+                {
+                    // Entfernungsabfragen zu den einzelnen Shop-Schildern. Verschachtelt für Performancebringenden Abbruch.
+                    if (((player distance east_shop_air) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_air) < MAX_DISTANCE_TO_SHOP)) then
                     {
-                        // Entfernungsabfragen zu den einzelnen Shop-Schildern. Verschachtelt für Performancebringenden Abbruch.
-                        if (((player distance east_shop_air) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_air) < MAX_DISTANCE_TO_SHOP)) then
+                        [EVENT_SHOP_KAUF_ONLOAD, ["choppers"]] call CFUNC(localEvent);
+                    }
+                    else
+                    {
+                        if (((player distance east_shop_veh) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_veh) < MAX_DISTANCE_TO_SHOP)) then
                         {
-                            [EVENT_SHOP_KAUF_ONLOAD, ["choppers"]] call CFUNC(localEvent);
+                            [EVENT_SHOP_KAUF_ONLOAD, ["vehicles"]] call CFUNC(localEvent);
                         }
                         else
                         {
-                            if (((player distance east_shop_veh) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_veh) < MAX_DISTANCE_TO_SHOP)) then
+                            if (((player distance east_shop_sup) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_sup) < MAX_DISTANCE_TO_SHOP)) then
                             {
-                                [EVENT_SHOP_KAUF_ONLOAD, ["vehicles"]] call CFUNC(localEvent);
+                                [EVENT_SHOP_KAUF_ONLOAD, ["supplies"]] call CFUNC(localEvent);
                             }
                             else
                             {
-                                if (((player distance east_shop_sup) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_sup) < MAX_DISTANCE_TO_SHOP)) then
+                                if (((player distance east_shop_sea) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_sea) < MAX_DISTANCE_TO_SHOP)) then
                                 {
-                                    [EVENT_SHOP_KAUF_ONLOAD, ["supplies"]] call CFUNC(localEvent);
+                                    [EVENT_SHOP_KAUF_ONLOAD, ["sea"]] call CFUNC(localEvent);
                                 }
                                 else
                                 {
-                                    if (((player distance east_shop_sea) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_sea) < MAX_DISTANCE_TO_SHOP)) then
+                                    if (((player distance east_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ1_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ2_shop_plane) < MAX_DISTANCE_TO_SHOP)) then
                                     {
-                                        [EVENT_SHOP_KAUF_ONLOAD, ["sea"]] call CFUNC(localEvent);
+                                        [EVENT_SHOP_KAUF_ONLOAD, ["planes"]] call CFUNC(localEvent);
                                     }
                                     else
                                     {
-                                        if (((player distance east_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ1_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ2_shop_plane) < MAX_DISTANCE_TO_SHOP)) then
+                                        if (((player distance east_shop_verkauf) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_verkauf) < MAX_DISTANCE_TO_SHOP)) then
                                         {
-                                            [EVENT_SHOP_KAUF_ONLOAD, ["planes"]] call CFUNC(localEvent);
-                                        }
-                                        else
-                                        {
-                                            if (((player distance east_shop_verkauf) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_verkauf) < MAX_DISTANCE_TO_SHOP)) then
-                                            {
-                                                [EVENT_SHOP_VERKAUF_ORDER, ["sell"]] call CFUNC(localEvent);
-                                            };
+                                            [EVENT_SHOP_VERKAUF_ORDER, ["sell"]] call CFUNC(localEvent);
                                         };
                                     };
                                 };
                             };
                         };
-                    },
-                    {},
-                    [
-                        DIK_F3, 
-                        [false, false, false] // [shift, ctrl, alt]
-                    ]
-                ] call CBA_fnc_addKeybind;
-            };
-
-            case "NATOvsCSAT":
-            {
-                //AddAction für Dialog öffnen
-                east_shop_air addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["choppers"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                west_shop_air addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["choppers"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-
-                east_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                west_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-                civ1_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                civ2_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-
-                east_shop_veh addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_GROUND)], {[EVENT_SHOP_KAUF_ONLOAD,["vehicles"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                west_shop_veh addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_GROUND)], {[EVENT_SHOP_KAUF_ONLOAD,["vehicles"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-
-                east_shop_sup addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_EQUIPMENT)], {[EVENT_SHOP_KAUF_ONLOAD,["supplies"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                west_shop_sup addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_EQUIPMENT)], {[EVENT_SHOP_KAUF_ONLOAD,["supplies"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-
-                east_shop_sea addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SEA)], {[EVENT_SHOP_KAUF_ONLOAD,["sea"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                west_shop_sea addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SEA)], {[EVENT_SHOP_KAUF_ONLOAD,["sea"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-
-                east_shop_verkauf addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SELL)], {[EVENT_SHOP_VERKAUF_ORDER,["sell"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                west_shop_verkauf addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SELL)], {[EVENT_SHOP_VERKAUF_ORDER,["sell"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-
-                //Shop Dialog öffnen
-                /*
-                * https://cbateam.github.io/CBA_A3/docs/files/keybinding/fnc_addKeybind-sqf.html
-                */
+                    };
+                },
+                {},
                 [
-                    "OPT", 
-                    "OPT Shop System", 
-                    ["Shop-Dialog öffnen", "Öffnet den Shop-Dialog im Fahnenbereich."], 
+                    DIK_F3, 
+                    [false, false, false] // [shift, ctrl, alt]
+                ]
+            ] call CBA_fnc_addKeybind;
+        };
+
+        case "NATOvsCSAT":
+        {
+            //AddAction für Dialog öffnen
+            east_shop_air addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["choppers"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            west_shop_air addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["choppers"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+
+            east_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            west_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+            civ1_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            civ2_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+
+            east_shop_veh addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_GROUND)], {[EVENT_SHOP_KAUF_ONLOAD,["vehicles"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            west_shop_veh addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_GROUND)], {[EVENT_SHOP_KAUF_ONLOAD,["vehicles"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+
+            east_shop_sup addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_EQUIPMENT)], {[EVENT_SHOP_KAUF_ONLOAD,["supplies"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            west_shop_sup addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_EQUIPMENT)], {[EVENT_SHOP_KAUF_ONLOAD,["supplies"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+
+            east_shop_sea addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SEA)], {[EVENT_SHOP_KAUF_ONLOAD,["sea"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            west_shop_sea addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SEA)], {[EVENT_SHOP_KAUF_ONLOAD,["sea"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+
+            east_shop_verkauf addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SELL)], {[EVENT_SHOP_VERKAUF_ORDER,["sell"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            west_shop_verkauf addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SELL)], {[EVENT_SHOP_VERKAUF_ORDER,["sell"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+
+            //Shop Dialog öffnen
+            /*
+            * https://cbateam.github.io/CBA_A3/docs/files/keybinding/fnc_addKeybind-sqf.html
+            */
+            [
+                "OPT", 
+                "OPT Shop System", 
+                ["Shop-Dialog öffnen", "Öffnet den Shop-Dialog im Fahnenbereich."], 
+                {
+                    // Entfernungsabfragen zu den einzelnen Shop-Schildern. Verschachtelt für Performancebringenden Abbruch.
+                    if (((player distance east_shop_air) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_air) < MAX_DISTANCE_TO_SHOP)) then
                     {
-                        // Entfernungsabfragen zu den einzelnen Shop-Schildern. Verschachtelt für Performancebringenden Abbruch.
-                        if (((player distance east_shop_air) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_air) < MAX_DISTANCE_TO_SHOP)) then
+                        [EVENT_SHOP_KAUF_ONLOAD, ["choppers"]] call CFUNC(localEvent);
+                    }
+                    else
+                    {
+                        if (((player distance east_shop_veh) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_veh) < MAX_DISTANCE_TO_SHOP)) then
                         {
-                            [EVENT_SHOP_KAUF_ONLOAD, ["choppers"]] call CFUNC(localEvent);
+                            [EVENT_SHOP_KAUF_ONLOAD, ["vehicles"]] call CFUNC(localEvent);
                         }
                         else
                         {
-                            if (((player distance east_shop_veh) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_veh) < MAX_DISTANCE_TO_SHOP)) then
+                            if (((player distance east_shop_sup) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_sup) < MAX_DISTANCE_TO_SHOP)) then
                             {
-                                [EVENT_SHOP_KAUF_ONLOAD, ["vehicles"]] call CFUNC(localEvent);
+                                [EVENT_SHOP_KAUF_ONLOAD, ["supplies"]] call CFUNC(localEvent);
                             }
                             else
                             {
-                                if (((player distance east_shop_sup) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_sup) < MAX_DISTANCE_TO_SHOP)) then
+                                if (((player distance east_shop_sea) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_sea) < MAX_DISTANCE_TO_SHOP)) then
                                 {
-                                    [EVENT_SHOP_KAUF_ONLOAD, ["supplies"]] call CFUNC(localEvent);
+                                    [EVENT_SHOP_KAUF_ONLOAD, ["sea"]] call CFUNC(localEvent);
                                 }
                                 else
                                 {
-                                    if (((player distance east_shop_sea) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_sea) < MAX_DISTANCE_TO_SHOP)) then
+                                    if (((player distance east_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ1_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ2_shop_plane) < MAX_DISTANCE_TO_SHOP)) then
                                     {
-                                        [EVENT_SHOP_KAUF_ONLOAD, ["sea"]] call CFUNC(localEvent);
+                                        [EVENT_SHOP_KAUF_ONLOAD, ["planes"]] call CFUNC(localEvent);
                                     }
                                     else
                                     {
-                                        if (((player distance east_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ1_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ2_shop_plane) < MAX_DISTANCE_TO_SHOP)) then
+                                        if (((player distance east_shop_verkauf) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_verkauf) < MAX_DISTANCE_TO_SHOP)) then
                                         {
-                                            [EVENT_SHOP_KAUF_ONLOAD, ["planes"]] call CFUNC(localEvent);
-                                        }
-                                        else
-                                        {
-                                            if (((player distance east_shop_verkauf) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_verkauf) < MAX_DISTANCE_TO_SHOP)) then
-                                            {
-                                                [EVENT_SHOP_VERKAUF_ORDER, ["sell"]] call CFUNC(localEvent);
-                                            };
+                                            [EVENT_SHOP_VERKAUF_ORDER, ["sell"]] call CFUNC(localEvent);
                                         };
                                     };
                                 };
                             };
                         };
-                    },
-                    {},
-                    [
-                        DIK_F3, 
-                        [false, false, false] // [shift, ctrl, alt]
-                    ]
-                ] call CBA_fnc_addKeybind;
-            };
-
-            case "NATOvsAAF":
-            {
-                //AddAction für Dialog öffnen
-                west_shop_air addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["choppers"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-                independent_shop_air addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["choppers"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-
-                west_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                independent_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-                civ1_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-                civ2_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
-
-                west_shop_veh addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_GROUND)], {[EVENT_SHOP_KAUF_ONLOAD,["vehicles"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-                independent_shop_veh addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_GROUND)], {[EVENT_SHOP_KAUF_ONLOAD,["vehicles"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-
-                west_shop_sup addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_EQUIPMENT)], {[EVENT_SHOP_KAUF_ONLOAD,["supplies"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-                independent_shop_sup addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_EQUIPMENT)], {[EVENT_SHOP_KAUF_ONLOAD,["supplies"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-
-                west_shop_sea addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SEA)], {[EVENT_SHOP_KAUF_ONLOAD,["sea"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-                independent_shop_sea addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SEA)], {[EVENT_SHOP_KAUF_ONLOAD,["sea"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-
-                west_shop_verkauf addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SELL)], {[EVENT_SHOP_VERKAUF_ORDER,["sell"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-                independent_shop_verkauf addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SELL)], {[EVENT_SHOP_VERKAUF_ORDER,["sell"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
-
-                //Shop Dialog öffnen
-                /*
-                * https://cbateam.github.io/CBA_A3/docs/files/keybinding/fnc_addKeybind-sqf.html
-                */
+                    };
+                },
+                {},
                 [
-                    "OPT", 
-                    "OPT Shop System", 
-                    ["Shop-Dialog öffnen", "Öffnet den Shop-Dialog im Fahnenbereich."], 
+                    DIK_F3, 
+                    [false, false, false] // [shift, ctrl, alt]
+                ]
+            ] call CBA_fnc_addKeybind;
+        };
+
+        case "NATOvsAAF":
+        {
+            //AddAction für Dialog öffnen
+            west_shop_air addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["choppers"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+            independent_shop_air addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["choppers"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+
+            west_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            independent_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+            civ1_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+            civ2_shop_plane addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_AIR)], {[EVENT_SHOP_KAUF_ONLOAD,["planes"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];
+
+            west_shop_veh addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_GROUND)], {[EVENT_SHOP_KAUF_ONLOAD,["vehicles"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+            independent_shop_veh addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_GROUND)], {[EVENT_SHOP_KAUF_ONLOAD,["vehicles"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+
+            west_shop_sup addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_EQUIPMENT)], {[EVENT_SHOP_KAUF_ONLOAD,["supplies"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+            independent_shop_sup addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_EQUIPMENT)], {[EVENT_SHOP_KAUF_ONLOAD,["supplies"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+
+            west_shop_sea addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SEA)], {[EVENT_SHOP_KAUF_ONLOAD,["sea"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+            independent_shop_sea addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SEA)], {[EVENT_SHOP_KAUF_ONLOAD,["sea"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+
+            west_shop_verkauf addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SELL)], {[EVENT_SHOP_VERKAUF_ORDER,["sell"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+            independent_shop_verkauf addAction [format["<t color=""#F60707"">%1</t>", MLOC(SHOPMENU_SELL)], {[EVENT_SHOP_VERKAUF_ORDER,["sell"]] call CFUNC(localEvent);},"", 6, false, true, "", ""];    
+
+            //Shop Dialog öffnen
+            /*
+            * https://cbateam.github.io/CBA_A3/docs/files/keybinding/fnc_addKeybind-sqf.html
+            */
+            [
+                "OPT", 
+                "OPT Shop System", 
+                ["Shop-Dialog öffnen", "Öffnet den Shop-Dialog im Fahnenbereich."], 
+                {
+                    // Entfernungsabfragen zu den einzelnen Shop-Schildern. Verschachtelt für Performancebringenden Abbruch.
+                    if (((player distance west_shop_air) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_air) < MAX_DISTANCE_TO_SHOP)) then
                     {
-                        // Entfernungsabfragen zu den einzelnen Shop-Schildern. Verschachtelt für Performancebringenden Abbruch.
-                        if (((player distance west_shop_air) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_air) < MAX_DISTANCE_TO_SHOP)) then
+                        [EVENT_SHOP_KAUF_ONLOAD, ["choppers"]] call CFUNC(localEvent);
+                    }
+                    else
+                    {
+                        if (((player distance west_shop_veh) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_veh) < MAX_DISTANCE_TO_SHOP)) then
                         {
-                            [EVENT_SHOP_KAUF_ONLOAD, ["choppers"]] call CFUNC(localEvent);
+                            [EVENT_SHOP_KAUF_ONLOAD, ["vehicles"]] call CFUNC(localEvent);
                         }
                         else
                         {
-                            if (((player distance west_shop_veh) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_veh) < MAX_DISTANCE_TO_SHOP)) then
+                            if (((player distance west_shop_sup) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_sup) < MAX_DISTANCE_TO_SHOP)) then
                             {
-                                [EVENT_SHOP_KAUF_ONLOAD, ["vehicles"]] call CFUNC(localEvent);
+                                [EVENT_SHOP_KAUF_ONLOAD, ["supplies"]] call CFUNC(localEvent);
                             }
                             else
                             {
-                                if (((player distance west_shop_sup) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_sup) < MAX_DISTANCE_TO_SHOP)) then
+                                if (((player distance west_shop_sea) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_sea) < MAX_DISTANCE_TO_SHOP)) then
                                 {
-                                    [EVENT_SHOP_KAUF_ONLOAD, ["supplies"]] call CFUNC(localEvent);
+                                    [EVENT_SHOP_KAUF_ONLOAD, ["sea"]] call CFUNC(localEvent);
                                 }
                                 else
                                 {
-                                    if (((player distance west_shop_sea) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_sea) < MAX_DISTANCE_TO_SHOP)) then
+                                    if (((player distance west_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ1_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ2_shop_plane) < MAX_DISTANCE_TO_SHOP)) then
                                     {
-                                        [EVENT_SHOP_KAUF_ONLOAD, ["sea"]] call CFUNC(localEvent);
+                                        [EVENT_SHOP_KAUF_ONLOAD, ["planes"]] call CFUNC(localEvent);
                                     }
                                     else
                                     {
-                                        if (((player distance west_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ1_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ2_shop_plane) < MAX_DISTANCE_TO_SHOP)) then
+                                        if (((player distance west_shop_verkauf) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_verkauf) < MAX_DISTANCE_TO_SHOP)) then
                                         {
-                                            [EVENT_SHOP_KAUF_ONLOAD, ["planes"]] call CFUNC(localEvent);
-                                        }
-                                        else
-                                        {
-                                            if (((player distance west_shop_verkauf) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_verkauf) < MAX_DISTANCE_TO_SHOP)) then
-                                            {
-                                                [EVENT_SHOP_VERKAUF_ORDER, ["sell"]] call CFUNC(localEvent);
-                                            };
+                                            [EVENT_SHOP_VERKAUF_ORDER, ["sell"]] call CFUNC(localEvent);
                                         };
                                     };
                                 };
                             };
                         };
-                    },
-                    {},
-                    [
-                        DIK_F3, 
-                        [false, false, false] // [shift, ctrl, alt]
-                    ]
-                ] call CBA_fnc_addKeybind;
-            };
+                    };
+                },
+                {},
+                [
+                    DIK_F3, 
+                    [false, false, false] // [shift, ctrl, alt]
+                ]
+            ] call CBA_fnc_addKeybind;
+        };
 
-            default 
-            {
-                ERROR_LOG("ShopClientInit: Fehlerhafte Datenuebergabe - Keine Fraktionauswahl erkannt");
-            };
+        default 
+        {
+            ERROR_LOG("ShopClientInit: Fehlerhafte Datenuebergabe - Keine Fraktionauswahl erkannt");
+        };
     };
 
     //TFAR Verschlüsselung bei Fahrzeugen

--- a/addons/main/SHOP/fn_clientInit.sqf
+++ b/addons/main/SHOP/fn_clientInit.sqf
@@ -143,6 +143,13 @@ GVAR(eventArgs) = [];
                                         if (((player distance east_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ1_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ2_shop_plane) < MAX_DISTANCE_TO_SHOP)) then
                                         {
                                             [EVENT_SHOP_KAUF_ONLOAD, ["planes"]] call CFUNC(localEvent);
+                                        }
+                                        else
+                                        {
+                                            if (((player distance east_shop_verkauf) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_verkauf) < MAX_DISTANCE_TO_SHOP)) then
+                                            {
+                                                [EVENT_SHOP_VERKAUF_ORDER, ["sell"]] call CFUNC(localEvent);
+                                            };
                                         };
                                     };
                                 };
@@ -217,6 +224,13 @@ GVAR(eventArgs) = [];
                                         if (((player distance east_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ1_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ2_shop_plane) < MAX_DISTANCE_TO_SHOP)) then
                                         {
                                             [EVENT_SHOP_KAUF_ONLOAD, ["planes"]] call CFUNC(localEvent);
+                                        }
+                                        else
+                                        {
+                                            if (((player distance east_shop_verkauf) < MAX_DISTANCE_TO_SHOP) or ((player distance west_shop_verkauf) < MAX_DISTANCE_TO_SHOP)) then
+                                            {
+                                                [EVENT_SHOP_VERKAUF_ORDER, ["sell"]] call CFUNC(localEvent);
+                                            };
                                         };
                                     };
                                 };
@@ -291,6 +305,13 @@ GVAR(eventArgs) = [];
                                         if (((player distance west_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ1_shop_plane) < MAX_DISTANCE_TO_SHOP) or ((player distance civ2_shop_plane) < MAX_DISTANCE_TO_SHOP)) then
                                         {
                                             [EVENT_SHOP_KAUF_ONLOAD, ["planes"]] call CFUNC(localEvent);
+                                        }
+                                        else
+                                        {
+                                            if (((player distance west_shop_verkauf) < MAX_DISTANCE_TO_SHOP) or ((player distance independent_shop_verkauf) < MAX_DISTANCE_TO_SHOP)) then
+                                            {
+                                                [EVENT_SHOP_VERKAUF_ORDER, ["sell"]] call CFUNC(localEvent);
+                                            };
                                         };
                                     };
                                 };

--- a/addons/main/SHOP/fn_create.sqf
+++ b/addons/main/SHOP/fn_create.sqf
@@ -87,6 +87,7 @@ DFUNC(createOrder) =
     //Objekt Erstellung 
     private _posi = getPosASL GVAR(order_box) vectorAdd [0, 0, 1000];
     private _veh = createVehicle [_class, _posi, [], 0, "NONE"];
+    _veh enableDynamicSimulation true;
     _veh setdir getdir GVAR(order_box);
     _veh setVectorUp vectorUp GVAR(order_box);
     _posi = getPosASL GVAR(order_box) vectorAdd [0, 0, HEIGHT_OFFSET];

--- a/addons/main/SHOP/fn_einlesenInShopDialog.sqf
+++ b/addons/main/SHOP/fn_einlesenInShopDialog.sqf
@@ -387,17 +387,17 @@ switch (_side) do
 {
     case west: 
     {
-        _rscPicture ctrlSetText "\A3\Data_F\Flags\Flag_NATO_CO.paa";
+        _rscPicture ctrlSetText "\opt\opt_client\addons\core\bilder\NATO-Logo.paa";
     };
 
     case east: 
     {
-        _rscPicture ctrlSetText "\A3\Data_F\Flags\Flag_CSAT_CO.paa";
+        _rscPicture ctrlSetText "\opt\opt_client\addons\core\bilder\WP_Logo.paa";
     };  
 
     case independent: 
     {
-        _rscPicture ctrlSetText "\A3\Data_F\Flags\Flag_AAF_CO.paa";
+        _rscPicture ctrlSetText "\opt\opt_client\addons\core\bilder\xxx-Logo.paa";
     };    
 };
 

--- a/addons/main/SHOP/fn_einlesenInShopDialog.sqf
+++ b/addons/main/SHOP/fn_einlesenInShopDialog.sqf
@@ -31,6 +31,10 @@ params
     ["_type", ""]
 ];
 
+// Shop gegen erneutes öffnen sperren (per Hotkey sonst mehrfach moeglich)
+if (GVAR(LOCK)) exitWith {};
+GVAR(LOCK) = true;
+
 //Hardcap Send Auslösung Zurücksetzen
 GVAR(Daten_send) = false;
 GVAR(Hardcap_pool) = [];
@@ -88,6 +92,13 @@ private _button21 = _display displayCtrl 20030;
 private _button22 = _display displayCtrl 20031;
 private _button23 = _display displayCtrl 20032;
 private _button24 = _display displayCtrl 20033;
+
+// ESC-Taste zum schliessen benutzt -> Dialog wieder freigeben
+_display displayAddEventhandler["KeyDown",
+{
+    params ["_display", "_key"];
+    if (_key == 1) exitWith {GVAR(LOCK) = false;};
+}];
 
 _order ctrlEnable false;
 _konfig ctrlEnable false;
@@ -434,6 +445,7 @@ _order ctrlAddEventHandler [ "ButtonClick",
     
     if (GVAR(moveInVeh)) then 
     {
+        GVAR(LOCK) = false;
         closeDialog 0;
     };
 
@@ -462,7 +474,7 @@ _moveInVeh ctrlAddEventHandler [ "ButtonClick",
     if (GVAR(moveInVeh)) then 
     {
         GVAR(moveInVeh) = false;         
-        _moveInVeh ctrlSetText "[_] Fahrzeug besetzen";   
+        _moveInVeh ctrlSetText "[  ] Fahrzeug besetzen";   
         _moveInVeh ctrlSetTextColor [1.0, 0.0, 0.0, 1];       
     }
     else

--- a/addons/main/SHOP/fn_einlesenInVerkaufDialog.sqf
+++ b/addons/main/SHOP/fn_einlesenInVerkaufDialog.sqf
@@ -31,6 +31,10 @@ params
     ["_type", ""]
 ];
 
+// Shop gegen erneutes öffnen sperren (per Hotkey sonst mehrfach moeglich)
+if (GVAR(LOCK)) exitWith {};
+GVAR(LOCK) = true;
+
 //Spieler Seite bestimmen
 private _side = playerside;
 
@@ -50,6 +54,13 @@ private _sell = _display displayCtrl 23103;
 private _rscPicture = _display displayCtrl IDC_PLAYER_FLAG;
 private _listbox_vehicles = _display displayCtrl IDC_CTRL_VEHICLE_LIST;
 private _editbox_info = _display displayCtrl IDC_CTRL_PRICE_LIST;
+
+// ESC-Taste zum schliessen benutzt -> Dialog wieder freigeben
+_display displayAddEventhandler["KeyDown",
+{
+    params ["_display", "_key"];
+    if (_key == 1) exitWith {GVAR(LOCK) = false;};
+}];
 
 _order ctrlEnable false;
 _sell ctrlShow false;

--- a/addons/main/SHOP/fn_einlesenInVerkaufDialog.sqf
+++ b/addons/main/SHOP/fn_einlesenInVerkaufDialog.sqf
@@ -75,21 +75,21 @@ switch (_side) do
 {
     case west: 
     {
-        _rscPicture ctrlSetText "\A3\Data_F\Flags\Flag_NATO_CO.paa";
+        _rscPicture ctrlSetText "\opt\opt_client\addons\core\bilder\NATO-Logo.paa";
 
         GVAR(pads) = [VerkaufsBoxWest];
     };
 
     case east: 
     {
-        _rscPicture ctrlSetText "\A3\Data_F\Flags\Flag_CSAT_CO.paa";
+        _rscPicture ctrlSetText "\opt\opt_client\addons\core\bilder\WP_Logo.paa";
 
         GVAR(pads) = [VerkaufsBoxEast];
     }; 
 
     case independent: 
     {
-        _rscPicture ctrlSetText "\A3\Data_F\Flags\Flag_AAF_CO.paa";
+        _rscPicture ctrlSetText "\opt\opt_client\addons\core\bilder\xxx-Logo.paa";
 
         GVAR(pads) = [VerkaufsBoxindependent];
     };   

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -2,7 +2,7 @@
 #define MAJOR 1
 #define MINOR 9
 #define PATCHLVL 2
-#define BUILD 18
+#define BUILD 20
 
 
 #ifdef VERSION

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -2,7 +2,7 @@
 #define MAJOR 1
 #define MINOR 9
 #define PATCHLVL 2
-#define BUILD 20
+#define BUILD 21
 
 
 #ifdef VERSION


### PR DESCRIPTION
- [x] Auftrennung Helikopter/Flugzeug zur Anpassung an die die Regeln
- [x] Serverseitiges Beaming mit Kollisionscheck
- [x] Unterscheidungen über Kartenname wieder entfernt
- [x] Dynamic Simulation eingeführt
- [x] Verkaufspads nun auch mit Hotkey steuerbar
- [x] Geschwindigkeit der Einheit beim Teleport wird auf 0 gesetzt so das man sich aus großer Höhe auf den Boden retten kann
- [x] Geschwindigkeit beim Beamen wird beibehalten
- [x] Internationalisierung bei Regelverstößen repariert
- [x] Beam für Luftfahrzeuge optimiert
- [x] Teleporting Sicherheit erhöht - Keine Probleme mit Bäumen mehr
- [x] Shops gegen mehrfaches öffnen geschützt (war per Hotkey möglich)
- [x] Teleportfunktion beim Schließen der Karte beenden, so das man später nicht aus versehen teleportiert