### PR TITLE
Spieleranzahl auf der Karte anzeigen, Cessna deaktiviert

### DIFF
--- a/addons/main/SECTORCONTROL/fn_serverInit.sqf
+++ b/addons/main/SECTORCONTROL/fn_serverInit.sqf
@@ -74,7 +74,51 @@ DFUNC(startflagsetup) =
     // Finale Fahnenmasten und Markierungen setzen
     [] call FUNC(setupflagpoles);
     [FUNC(startflagsetup), {(OPT_GELDZEIT_GAMESTAGE == GAMESTAGE_WAR)}, "Awesome Delay"] call CLib_fnc_waitUntil;
+
+    // Marker für Spieleranzahl löschen
+    GVAR(playercount_handler) call CBA_fnc_removePerFrameHandler;
+    deleteMarker "Marker_NumPlayers";
 }] call CFUNC(addEventhandler);
 
 // Sektoren initialisieren (Sektormarker, Flaggenpositionen, Beampunkte)
 [] call FUNC(setupsectors);
+
+// Anzeige der Anzahl von eingeslotteten Spielern als Marker auf der Karte
+// Wie oft (in Sekunden) wird die Spieleranzahl aktualisiert
+#define PLAYERCOUNT_INTERVAL 1
+
+private _worldsize = (worldName call BIS_fnc_mapSize);
+createMarkerLocal ["Marker_NumPlayers", [0, worldsize + 500]];
+"Marker_NumPlayers" setMarkerTypeLocal "hd_end_noShadow";  
+"Marker_NumPlayers" setMarkerColorLocal "ColorBlack";  
+"Marker_NumPlayers" setMarkerSizeLocal [1, 1];
+"Marker_NumPlayers" setMarkerAlphaLocal 1;
+
+switch OPT_GELDZEIT_Fraktionauswahl do 
+{
+    case "AAFvsCSAT":
+    {
+        GVAR(playercount_handler) =
+        [{
+            "Marker_NumPlayers" setMarkerText format["Eingeslottet: AAF: %1 // CSAT: %2", playersNumber independent, playersNumber east];
+        }, PLAYERCOUNT_INTERVAL] call CBA_fnc_addPerFrameHandler;    // Der CLib PFH funktioniert hier noch nicht vor dem Missionsstart
+    };
+    case "NATOvsCSAT":
+    {
+        GVAR(playercount_handler) =
+        [{
+            "Marker_NumPlayers" setMarkerText format["Eingeslottet: NATO: %1 // CSAT: %2", playersNumber west, playersNumber east];
+        }, PLAYERCOUNT_INTERVAL] call CBA_fnc_addPerFrameHandler;    // Der CLib PFH funktioniert hier noch nicht vor dem Missionsstart
+    };
+    case "NATOvsAAF":
+    {
+        GVAR(playercount_handler) =
+        [{
+            "Marker_NumPlayers" setMarkerText format["Eingeslottet: NATO: %1 // AAF: %2", playersNumber west, playersNumber independent];
+        }, PLAYERCOUNT_INTERVAL] call CBA_fnc_addPerFrameHandler;    // Der CLib PFH funktioniert hier noch nicht vor dem Missionsstart
+    };
+    default 
+    {
+        ERROR_LOG("RulesClientInit: Fehlerhafte Datenübergabe - Keine Fraktionauswahl erkannt");
+    };
+};

--- a/addons/main/SHOP/fn_config.sqf
+++ b/addons/main/SHOP/fn_config.sqf
@@ -118,7 +118,7 @@ GVAR(nato_choppers) =
 
 GVAR(nato_planes) =
 [
-    ["OPT_CUP_C_Cessna_172_CIV_BLUE", DEF_PROD(30000)],     // Caesar BTT
+//    ["OPT_CUP_C_Cessna_172_CIV_BLUE", DEF_PROD(30000)],     // Caesar BTT
     ["OPT_CUP_C_AN2_CIV", DEF_PROD(30000)],                         // Antonov An-2
     ["OPT_CUP_C_DC3_ChernAvia_CIV", DEF_PROD(30000)],               // Li-2
     ["OPT_CUP_B_C130J_USMC", DEF_PROD(40000)],                      // C130J
@@ -310,7 +310,7 @@ GVAR(csat_choppers) =
 
 GVAR(csat_planes) =
 [
-    ["OPT_CUP_C_Cessna_172_CIV_GREEN", DEF_PROD(30000)],                // Cessna
+//    ["OPT_CUP_C_Cessna_172_CIV_GREEN", DEF_PROD(30000)],                // Cessna
     ["OPT_CUP_O_AN2_TK", DEF_PROD(30000)],                              // Antonov An-2
     ["OPT_CUP_O_C47_SLA", DEF_PROD(30000)],                             // Li-2
     ["OPT_CUP_O_C130J_TKA", DEF_PROD(40000)],                           // C130J

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -2,7 +2,7 @@
 #define MAJOR 1
 #define MINOR 9
 #define PATCHLVL 2
-#define BUILD 28
+#define BUILD 29
 
 
 #ifdef VERSION


### PR DESCRIPTION
- [x] Die Anzahl der eingeslotteten Spieler wird auf der Karte als Marker angezeigt, solange der Admin noch nicht "durchgedrückt" hat
- [x] Cessna deaktiviert